### PR TITLE
Implement Merge

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -318,9 +318,8 @@ def test_merge(coco_path, tmpdir):
         root_dir=tmpdir,
     )
 
-    assert (ds.raw_image_dir / "0_ds1").exists()
-    assert (ds.raw_image_dir / "1_ds2").exists()
-    assert len(ds.images) == 200
+    assert (ds.raw_image_dir).exists()
+    assert len(ds.images) == 100
     assert len(ds.annotations) == 200
     assert len(ds.categories) == 2
     assert (
@@ -343,7 +342,7 @@ def test_merge(coco_path, tmpdir):
         root_dir=tmpdir,
     )
 
-    assert len(ds.images) == 200
+    assert len(ds.images) == 100
     assert len(ds.annotations) == 200
     assert len(ds.categories) == 3
     assert (

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -316,6 +316,7 @@ def test_merge(coco_path, tmpdir):
         src_names=["ds1", "ds2"],
         src_root_dirs=[tmpdir, tmpdir],
         root_dir=tmpdir,
+        task=TaskType.OBJECT_DETECTION,
     )
 
     assert (ds.raw_image_dir).exists()
@@ -340,11 +341,13 @@ def test_merge(coco_path, tmpdir):
         src_names=["ds1", "ds2"],
         src_root_dirs=[tmpdir, tmpdir],
         root_dir=tmpdir,
+        task=TaskType.OBJECT_DETECTION,
     )
 
     assert len(ds.images) == 100
     assert len(ds.annotations) == 100 + category_1_num
     assert len(ds.categories) == 3
+
     assert (
         len([0 for annotation in ds.annotations.values() if annotation.category_id == 1])
         == category_1_num

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -320,15 +320,15 @@ def test_merge(coco_path, tmpdir):
 
     assert (ds.raw_image_dir).exists()
     assert len(ds.images) == 100
-    assert len(ds.annotations) == 200
+    assert len(ds.annotations) == 100
     assert len(ds.categories) == 2
     assert (
         len([0 for annotation in ds.annotations.values() if annotation.category_id == 1])
-        == category_1_num * 2
+        == category_1_num
     )
     assert (
         len([0 for annotation in ds.annotations.values() if annotation.category_id == 2])
-        == category_2_num * 2
+        == category_2_num
     )
 
     category = load_json(ds1.category_dir / "1.json")
@@ -343,7 +343,7 @@ def test_merge(coco_path, tmpdir):
     )
 
     assert len(ds.images) == 100
-    assert len(ds.annotations) == 200
+    assert len(ds.annotations) == 100 + category_1_num
     assert len(ds.categories) == 3
     assert (
         len([0 for annotation in ds.annotations.values() if annotation.category_id == 1])
@@ -351,7 +351,7 @@ def test_merge(coco_path, tmpdir):
     )
     assert (
         len([0 for annotation in ds.annotations.values() if annotation.category_id == 2])
-        == category_2_num * 2
+        == category_2_num
     )
     assert (
         len([0 for annotation in ds.annotations.values() if annotation.category_id == 3])

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -314,7 +314,21 @@ class Dataset:
         root_dir: str,
         src_names: list[str],
         src_root_dirs: list[str],
-    ):
+    ) -> "Dataset":
+        """
+        Merge Datasets.
+        This method merges multiple datasets into one dataset.
+
+        Args:
+            name (str): New Dataset name
+            root_dir (str): New Dataset root directory
+            src_names (list[str]): Source Dataset names
+            src_root_dirs (list[str]): Source Dataset root directories
+
+        Returns:
+            Dataset: Dataset Class
+
+        """
         if len(src_names) != len(src_root_dirs):
             raise ValueError("Length of src_names and src_root_dirs should be same.")
 
@@ -377,6 +391,8 @@ class Dataset:
             if ds.dataset_dir.exists():
                 io.remove_directory(ds.dataset_dir)
             raise e
+
+        return Dataset.load(name, root_dir)
 
     @classmethod
     def from_coco(

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -396,13 +396,17 @@ class Dataset:
                 # merge - sets
                 if src_ds.set_dir.exists():
                     for set_file in ["train.json", "val.json", "test.json"]:
+                        src_set_file_path = src_ds.set_dir / set_file
                         tar_set_file_path = ds.set_dir / set_file
+
+                        if not src_set_file_path.exists():
+                            continue
+
                         if tar_set_file_path.exists():
                             set_ids = io.load_json(tar_set_file_path)
                         else:
                             set_ids = []
 
-                        src_set_file_path = src_ds.set_dir / set_file
                         src_set_ids = io.load_json(src_set_file_path)
                         src_set_ids = [set_id + start_image_id for set_id in src_set_ids]
                         set_ids.extend(src_set_ids)

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -349,9 +349,7 @@ class Dataset:
         had_image_paths = set(get_image_files(merged_ds.raw_image_dir))
 
         try:
-            for i, (src_name, src_root_dir) in enumerate(
-                zip(src_names[1:], src_root_dirs[1:]), start=1
-            ):
+            for src_name, src_root_dir in zip(src_names[1:], src_root_dirs[1:]):
                 src_ds = Dataset.load(src_name, src_root_dir)
                 if src_ds.task != merged_ds.task:
                     raise ValueError(

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -386,15 +386,15 @@ class Dataset:
                         changed_image_ids[ori_image_id] = image.image_id
 
                     # merge - annotations
-                    for annotation in src_ds.image_to_annotations[ori_image_id]:
-                        annotation.image_id = image.image_id
-                        annotation.annotation_id = new_annotation_id
+                    for src_ann in src_ds.image_to_annotations[ori_image_id]:
+                        src_ann.image_id = image.image_id
+                        src_ann.annotation_id = new_annotation_id
                         new_annotation_id += 1
 
-                        category_name = src_ds.categories[annotation.category_id].name
-                        annotation.category_id = category2id[category_name]
+                        category_name = src_ds.categories[src_ann.category_id].name
+                        src_ann.category_id = category2id[category_name]
 
-                        merged_ds.add_annotations([annotation])
+                        merged_ds.add_annotations([src_ann])
 
         except Exception as e:
             if merged_ds.dataset_dir.exists():

--- a/waffle_hub/schema/fields/annotation.py
+++ b/waffle_hub/schema/fields/annotation.py
@@ -190,6 +190,30 @@ class Annotation(BaseField):
             raise ValueError(f"Invalid task type: {v}" f"Available task types: {list(TaskType)}")
         self.__task = str(v).upper()
 
+    def __eq__(self, other):
+        if not isinstance(other, Annotation):
+            return False
+
+        if self.task == TaskType.CLASSIFICATION:
+            return self.category_id == other.category_id
+
+        elif self.task == TaskType.OBJECT_DETECTION:
+            return (
+                self.category_id == other.category_id
+                and self.bbox == other.bbox
+                and self.iscrowd == other.iscrowd
+            )
+
+        elif self.task == TaskType.INSTANCE_SEGMENTATION:
+            return (
+                self.category_id == other.category_id
+                and self.segmentation == other.segmentation
+                and self.iscrowd == other.iscrowd
+            )
+
+        else:
+            raise NotImplementedError(f"Task type {self.task} is not supported.")
+
     # factories
     @classmethod
     def new(


### PR DESCRIPTION
1. The file path of an image is assumed to be unique.
2. annotations are always added
3. If the category names are the same, they are treated as the same category.
```
ds1's categories = {1:"1", 2:"2"}
ds2's categories = {1:"1", 2:"3"}

ds = Dataset.merge(...)
ds's categories = {1:"1", 2:"2", 3:"3"}
```

usage:
```
ds = Dataset.merge(
    name="merge",
    root_dir="datasets",
    src_names=["mnist_clone", "mnist"],
    src_root_dirs=["datasets", "datasets"],
)
```