### PR TITLE
fix cached_property and check non-depulicate category

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -251,7 +251,7 @@ def _dummy(dataset_name, task: TaskType, image_num, category_num, unlabeled_imag
         task=task,
         image_num=image_num,
         category_num=category_num,
-        unlabeld_image_num=unlabeled_image_num,
+        unlabeled_image_num=unlabeled_image_num,
         root_dir=root_dir,
     )
     assert len(dataset.images) == image_num

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -541,5 +541,8 @@ def test_cached_property(tmpdir):
     ds.add_categories([new_cate])
     assert len(ds.categories) == len(before_cates) + 1
     assert len(ds.category_names) == len(before_cate_names) + 1
-    assert len(ds.category_to_images.keys()) == len(before_cate_to_imgs.keys()) + 1
+
+    new_ann = Annotation.classification(11, 11, 2)
+    ds.add_annotations([new_ann])
     assert len(ds.category_to_annotations.keys()) == len(before_cate_to_anns.keys()) + 1
+    assert len(ds.category_to_images.keys()) == len(before_cate_to_imgs.keys()) + 1

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -349,7 +349,10 @@ def _total_transformers(dataset_name, task: TaskType, transformers_path, root_di
 
 def test_transformers(transformers_detection_path, transformers_classification_path, tmpdir):
     _total_transformers(
-        "transformers_object_detection", TaskType.OBJECT_DETECTION, transformers_detection_path, tmpdir
+        "transformers_object_detection",
+        TaskType.OBJECT_DETECTION,
+        transformers_detection_path,
+        tmpdir,
     )
     _total_transformers(
         "transformers_classification",

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -217,22 +217,18 @@ class Dataset:
 
     @cached_property
     def image_to_annotations(self) -> dict[int, list[Annotation]]:
-        image_to_annotations = {image_id: [] for image_id in self.images.keys()}
-        for annotation in tqdm.tqdm(
-            self.annotations.values(), desc="Building image to annotation index"
-        ):
+        image_to_annotations = defaultdict(list)
+        for annotation in self.annotations.values():
             image_to_annotations[annotation.image_id].append(annotation)
         return dict(image_to_annotations)
 
     @cached_property
     def category_to_annotations(self) -> dict[int, list[Annotation]]:
-        category_to_annotations = {category_id: [] for category_id in self.categories.keys()}
+        category_to_annotations = defaultdict(list)
         category_name_to_id = {
             category.name: category.category_id for category in self.categories.values()
         }
-        for annotation in tqdm.tqdm(
-            self.annotations.values(), desc="Building category to annotation index"
-        ):
+        for annotation in self.annotations.values():
             if self.task == TaskType.TEXT_RECOGNITION:
                 texts = annotation.caption
                 characters = set(texts)
@@ -244,13 +240,11 @@ class Dataset:
 
     @cached_property
     def category_to_images(self) -> dict[int, list[Image]]:
-        category_to_images = {category_id: [] for category_id in self.categories.keys()}
+        category_to_images = defaultdict(list)
         category_name_to_id = {
             category.name: category.category_id for category in self.categories.values()
         }
-        for image_id, annotations in tqdm.tqdm(
-            self.image_to_annotations.items(), desc="Building category to image index"
-        ):
+        for image_id, annotations in self.image_to_annotations.items():
             if self.task == TaskType.TEXT_RECOGNITION:
                 texts = map(lambda a: a.caption, annotations)
                 character_count = Counter("".join(texts))
@@ -264,9 +258,9 @@ class Dataset:
 
     @cached_property
     def num_images_per_category(self) -> dict[int, int]:
-        num_images_per_category = {
-            category_id: len(images) for category_id, images in self.category_to_images.items()
-        }
+        num_images_per_category = defaultdict(int)
+        for category_id, images in self.category_to_images.items():
+            num_images_per_category[category_id] = len(images)
         return num_images_per_category
 
     @cached_property

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -3,7 +3,7 @@ import logging
 import random
 import shutil
 import warnings
-from collections import Counter, OrderedDict, defaultdict
+from collections import Counter, OrderedDict
 from functools import cached_property
 from pathlib import Path
 from tempfile import mkdtemp
@@ -194,7 +194,7 @@ class Dataset:
 
     @cached_property
     def image_to_annotations(self) -> dict[int, list[Annotation]]:
-        image_to_annotations = defaultdict(list)
+        image_to_annotations = {image_id: [] for image_id in self.images.keys()}
         for annotation in tqdm.tqdm(
             self.annotations.values(), desc="Building image to annotation index"
         ):
@@ -203,7 +203,7 @@ class Dataset:
 
     @cached_property
     def category_to_annotations(self) -> dict[int, list[Annotation]]:
-        category_to_annotations = defaultdict(list)
+        category_to_annotations = {category_id: [] for category_id in self.categories.keys()}
         for annotation in tqdm.tqdm(
             self.annotations.values(), desc="Building category to annotation index"
         ):
@@ -331,7 +331,7 @@ class Dataset:
         task: str,
         image_num: int = 100,
         category_num: int = 10,
-        unlabeld_image_num: int = 0,
+        unlabeled_image_num: int = 0,
         root_dir: str = None,
     ) -> "Dataset":
         """
@@ -443,8 +443,8 @@ class Dataset:
                 ds.add_annotations(annotations)
                 annotation_id += len(annotations)
 
-            if unlabeld_image_num > 0:
-                for image_id in range(image_num + 1, image_num + unlabeld_image_num + 1):
+            if unlabeled_image_num > 0:
+                for image_id in range(image_num + 1, image_num + unlabeled_image_num + 1):
                     file_name = f"image_{image_id}.jpg"
                     ds.add_images(
                         [Image(image_id=image_id, file_name=file_name, width=100, height=100)]
@@ -1432,6 +1432,8 @@ class Dataset:
             annotations (list[Annotation]): list of "Annotation"s
         """
         self.__dict__.pop("annotations", None)
+        self.__dict__.pop("image_to_annotations", None)
+        self.__dict__.pop("images", None)
         for item in annotations:
             if self.task == TaskType.TEXT_RECOGNITION:
                 for char in item.caption:

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -252,8 +252,17 @@ class Dataset:
     @cached_property
     def category_to_annotations(self) -> dict[int, list[Annotation]]:
         category_to_annotations = {category_id: [] for category_id in self.categories.keys()}
+        category_name_to_id = {
+            category.name: category.category_id for category in self.categories.values()
+        }
         for annotation in self.annotations.values():
-            category_to_annotations[annotation.category_id].append(annotation)
+            if self.task == TaskType.TEXT_RECOGNITION:
+                texts = annotation.caption
+                characters = set(texts)
+                for char in characters:
+                    category_to_annotations[category_name_to_id[char]].append(annotation)
+            else:
+                category_to_annotations[annotation.category_id].append(annotation)
         return dict(category_to_annotations)
 
     @cached_property

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -1427,13 +1427,13 @@ class Dataset:
         Args:
             categories (list[Category]): list of "Category"s
         """
-        # category_names_list = [category.name for category in categories]
-        # category_names = set(category_names_list)
-        # if (
-        #     len(category_names) != len(category_names_list)
-        #     or set(self.category_names) & category_names
-        # ):
-        #     raise ValueError("Category names should be unique")
+        category_names_list = [category.name for category in categories]
+        category_names = set(category_names_list)
+        if (
+            len(category_names) != len(category_names_list)
+            or set(self.category_names) & category_names
+        ):
+            raise ValueError("Category names should be unique")
 
         for item in categories:
             item_id = item.category_id

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -623,7 +623,7 @@ class Dataset:
                 io.remove_directory(merged_ds.dataset_dir)
             raise e
 
-        return merged_ds
+        return Dataset.load(name, root_dir)
 
     @classmethod
     def from_coco(

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -56,9 +56,9 @@ class Dataset:
         func = getattr(self, function_name)
 
         def wrapper(*args, **kwargs):
+            return_value = func(*args, **kwargs)
             if hasattr(self, property_name):
                 delattr(self, property_name)
-            return_value = func(*args, **kwargs)
             return return_value
 
         setattr(self, function_name, wrapper)
@@ -78,14 +78,18 @@ class Dataset:
 
         self.update_hook("categories", "add_categories")
         self.update_hook("category_names", "add_categories")
-        self.update_hook("images", "add_annotations")
+
         self.update_hook("unlabeled_images", "add_images")
-        self.update_hook("annotations", "add_annotations")
-        self.update_hook("image_to_annotations", "add_annotations")
-        self.update_hook("category_to_annotations", "add_annotations")
-        self.update_hook("category_to_images", "add_annotations")
+        self.update_hook("category_to_images", "add_images")
         self.update_hook("num_images_per_category", "add_images")
+
+        self.update_hook("annotations", "add_annotations")
+        self.update_hook("images", "add_annotations")
+        self.update_hook("image_to_annotations", "add_annotations")
+        self.update_hook("category_to_images", "add_annotations")
+        self.update_hook("category_to_annotations", "add_annotations")
         self.update_hook("num_annotations_per_category", "add_annotations")
+        self.update_hook("num_images_per_category", "add_annotations")
 
     # properties
     @property
@@ -226,7 +230,7 @@ class Dataset:
     def category_to_annotations(self) -> dict[int, list[Annotation]]:
         category_to_annotations = defaultdict(list)
         category_name_to_id = {
-            category.name: category.category_id for category in self.categories.values()
+            category.name: category.category_id for category in self.get_categories()
         }
         for annotation in self.annotations.values():
             if self.task == TaskType.TEXT_RECOGNITION:
@@ -242,7 +246,7 @@ class Dataset:
     def category_to_images(self) -> dict[int, list[Image]]:
         category_to_images = defaultdict(list)
         category_name_to_id = {
-            category.name: category.category_id for category in self.categories.values()
+            category.name: category.category_id for category in self.get_categories()
         }
         for image_id, annotations in self.image_to_annotations.items():
             if self.task == TaskType.TEXT_RECOGNITION:


### PR DESCRIPTION
fix cached_property and check non-depulicate category

before:
dataset.category_names #output: ["1","2"]
dataset.add_categories([category]) # new category's name is "3"
dataset.category_names # expect: ["1","2","3"], but result is ["1","2"]

I modified the cached property to ensure that the expected value is obtained.
