### PR TITLE
fix cached_property and check non-depulicate category

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -456,11 +456,9 @@ def test_merge(coco_path, tmpdir):
         root_dir=tmpdir,
     )
 
-    cateids_of_ann = [annotation.category_id for annotation in ds1.get_annotations()]
-    category_counts = Counter(cateids_of_ann)
-
-    category_1_num = category_counts[1]
-    category_2_num = category_counts[2]
+    num_ann_per_cate = ds1.get_num_annotations_per_category()
+    category_1_num = num_ann_per_cate[1]
+    category_2_num = num_ann_per_cate[2]
 
     ds = Dataset.merge(
         name="merge",
@@ -470,15 +468,14 @@ def test_merge(coco_path, tmpdir):
         task=TaskType.OBJECT_DETECTION,
     )
 
-    cateids_of_ann = [annotation.category_id for annotation in ds.get_annotations()]
-    category_counts = Counter(cateids_of_ann)
+    merged_num_ann_per_cate = ds1.get_num_annotations_per_category()
 
     assert (ds.raw_image_dir).exists()
     assert len(ds.get_images()) == 100
     assert len(ds.get_annotations()) == 100
     assert len(ds.get_categories()) == 2
-    assert category_counts[1] == category_1_num
-    assert category_counts[2] == category_2_num
+    assert merged_num_ann_per_cate[1] == category_1_num
+    assert merged_num_ann_per_cate[2] == category_2_num
 
     # test merge with different category name
     category = load_json(ds1.category_dir / "1.json")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -251,7 +251,7 @@ def _dummy(dataset_name, task: TaskType, image_num, category_num, unlabeled_imag
         task=task,
         image_num=image_num,
         category_num=category_num,
-        unlabeld_image_num=unlabeled_image_num,
+        unlabeled_image_num=unlabeled_image_num,
         root_dir=root_dir,
     )
     assert len(dataset.images) == image_num
@@ -541,5 +541,8 @@ def test_cached_property(tmpdir):
     ds.add_categories([new_cate])
     assert len(ds.categories) == len(before_cates) + 1
     assert len(ds.category_names) == len(before_cate_names) + 1
-    assert len(ds.category_to_images.keys()) == len(before_cate_to_imgs.keys()) + 1
+
+    new_ann = Annotation.classification(11, 11, 2)
+    ds.add_annotations([new_ann])
     assert len(ds.category_to_annotations.keys()) == len(before_cate_to_anns.keys()) + 1
+    assert len(ds.category_to_images.keys()) == len(before_cate_to_imgs.keys()) + 1

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -349,7 +349,10 @@ def _total_transformers(dataset_name, task: TaskType, transformers_path, root_di
 
 def test_transformers(transformers_detection_path, transformers_classification_path, tmpdir):
     _total_transformers(
-        "transformers_object_detection", TaskType.OBJECT_DETECTION, transformers_detection_path, tmpdir
+        "transformers_object_detection",
+        TaskType.OBJECT_DETECTION,
+        transformers_detection_path,
+        tmpdir,
     )
     _total_transformers(
         "transformers_classification",

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -474,9 +474,9 @@ def test_merge(coco_path, tmpdir):
     category_counts = Counter(cateids_of_ann)
 
     assert (ds.raw_image_dir).exists()
-    assert len(ds.images) == 100
-    assert len(ds.annotations) == 100
-    assert len(ds.categories) == 2
+    assert len(ds.get_images()) == 100
+    assert len(ds.get_annotations()) == 100
+    assert len(ds.get_categories()) == 2
     assert category_counts[1] == category_1_num
     assert category_counts[2] == category_2_num
 

--- a/tests/test_ddp.py
+++ b/tests/test_ddp.py
@@ -45,7 +45,7 @@ def test_ultralytics_segmentation(instance_segmentation_dataset: Dataset, tmpdir
         task=TaskType.INSTANCE_SEGMENTATION,
         model_type="yolov8",
         model_size="n",
-        categories=dataset.category_names,
+        categories=dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = UltralyticsHub.load(name=name, root_dir=tmpdir)
@@ -69,7 +69,7 @@ def test_ultralytics_object_detection(object_detection_dataset: Dataset, tmpdir:
         task=TaskType.OBJECT_DETECTION,
         model_type="yolov8",
         model_size="n",
-        categories=dataset.category_names,
+        categories=dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = UltralyticsHub.load(name=name, root_dir=tmpdir)
@@ -93,7 +93,7 @@ def test_ultralytics_classification(classification_dataset: Dataset, tmpdir: Pat
         task=TaskType.CLASSIFICATION,
         model_type="yolov8",
         model_size="n",
-        categories=classification_dataset.category_names,
+        categories=classification_dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = UltralyticsHub.load(name=name, root_dir=tmpdir)

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -163,7 +163,7 @@ def test_ultralytics_segmentation(instance_segmentation_dataset: Dataset, tmpdir
         task=TaskType.INSTANCE_SEGMENTATION,
         model_type="yolov8",
         model_size="n",
-        categories=dataset.category_names,
+        categories=dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = UltralyticsHub.load(name=name, root_dir=tmpdir)
@@ -187,7 +187,7 @@ def test_ultralytics_object_detection(object_detection_dataset: Dataset, tmpdir:
         task=TaskType.OBJECT_DETECTION,
         model_type="yolov8",
         model_size="n",
-        categories=dataset.category_names,
+        categories=dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = UltralyticsHub.load(name=name, root_dir=tmpdir)
@@ -211,7 +211,7 @@ def test_ultralytics_classification(classification_dataset: Dataset, tmpdir: Pat
         task=TaskType.CLASSIFICATION,
         model_type="yolov8",
         model_size="n",
-        categories=classification_dataset.category_names,
+        categories=classification_dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = UltralyticsHub.load(name=name, root_dir=tmpdir)
@@ -235,7 +235,7 @@ def test_transformers_object_detection(object_detection_dataset: Dataset, tmpdir
         task=TaskType.OBJECT_DETECTION,
         model_type="YOLOS",
         model_size="tiny",
-        categories=object_detection_dataset.category_names,
+        categories=object_detection_dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = TransformersHub.load(name=name, root_dir=tmpdir)
@@ -259,7 +259,7 @@ def test_transformers_classification(classification_dataset: Dataset, tmpdir: Pa
         task=TaskType.CLASSIFICATION,
         model_type="ViT",
         model_size="tiny",
-        categories=classification_dataset.category_names,
+        categories=classification_dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = TransformersHub.load(name=name, root_dir=tmpdir)
@@ -283,7 +283,7 @@ def test_non_hold(classification_dataset: Dataset, tmpdir: Path):
         task=TaskType.CLASSIFICATION,
         model_type="yolov8",
         model_size="n",
-        categories=classification_dataset.category_names,
+        categories=classification_dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = UltralyticsHub.load(name=name, root_dir=tmpdir)
@@ -307,7 +307,7 @@ def test_autocare_dlt_object_detection(object_detection_dataset: Dataset, tmpdir
         task=TaskType.OBJECT_DETECTION,
         model_type="YOLOv5",
         model_size="s",
-        categories=object_detection_dataset.category_names,
+        categories=object_detection_dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = AutocareDLTHub.load(name=name, root_dir=tmpdir)
@@ -325,7 +325,7 @@ def test_autocare_dlt_classification(classification_dataset: Dataset, tmpdir: Pa
     dataset = classification_dataset
 
     # temporal solution
-    super_cat = [[c.supercategory, c.name] for c in dataset.categories.values()]
+    super_cat = [[c.supercategory, c.name] for c in dataset.get_categories()]
     super_cat_dict = {}
     for super_cat, cat in super_cat:
         if super_cat not in super_cat_dict:
@@ -367,7 +367,7 @@ def test_autocare_dlt_text_recognition(text_recognition_dataset: Dataset, tmpdir
         task=TaskType.TEXT_RECOGNITION,
         model_type="TextRecognition",
         model_size="s",
-        categories=dataset.category_names,
+        categories=dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = AutocareDLTHub.load(name=name, root_dir=tmpdir)

--- a/waffle_hub/dataset/adapter/autocare_dlt.py
+++ b/waffle_hub/dataset/adapter/autocare_dlt.py
@@ -42,15 +42,13 @@ def _export_autocare_dlt(
                     "name": category.name,
                     "supercategory": category.supercategory,
                 }
-                for category in self.categories.values()
+                for category in self.get_categories()
             ],
             "images": [],
             "annotations": [],
         }
-        category_names = [category.name for category in self.categories.values()]
 
-        for image_id in image_ids:
-            image = self.images[image_id]
+        for image_id, image in enumerate(self.get_images([image_ids]), start=1):
             image_path = self.raw_image_dir / image.file_name
             image_dst_path = image_dir / image.file_name
             io.copy_file(image_path, image_dst_path, create_directory=True)
@@ -59,8 +57,7 @@ def _export_autocare_dlt(
             image_id = d.pop("image_id")
             coco["images"].append({"id": image_id, **d})
 
-            annotations = self.image_to_annotations[image_id]
-            for annotation in annotations:
+            for annotation in self.get_annotations(image_id):
                 d = annotation.to_dict()
                 if d.get("segmentation", None):
                     if isinstance(d["segmentation"], dict):

--- a/waffle_hub/dataset/adapter/autocare_dlt.py
+++ b/waffle_hub/dataset/adapter/autocare_dlt.py
@@ -48,7 +48,7 @@ def _export_autocare_dlt(
             "annotations": [],
         }
 
-        for image_id, image in enumerate(self.get_images([image_ids]), start=1):
+        for image in self.get_images(image_ids):
             image_path = self.raw_image_dir / image.file_name
             image_dst_path = image_dir / image.file_name
             io.copy_file(image_path, image_dst_path, create_directory=True)

--- a/waffle_hub/dataset/adapter/coco.py
+++ b/waffle_hub/dataset/adapter/coco.py
@@ -48,8 +48,7 @@ def _export_coco(
             "annotations": [],
         }
 
-        for image_id in image_ids:
-            image = self.get_images([image_id])
+        for image in self.get_images(image_ids):
             image_path = self.raw_image_dir / image.file_name
             image_dst_path = image_dir / image.file_name
             io.copy_file(image_path, image_dst_path, create_directory=True)

--- a/waffle_hub/dataset/adapter/coco.py
+++ b/waffle_hub/dataset/adapter/coco.py
@@ -42,14 +42,14 @@ def _export_coco(
                     "name": category.name,
                     "supercategory": category.supercategory,
                 }
-                for category in self.categories.values()
+                for category in self.get_categories()
             ],
             "images": [],
             "annotations": [],
         }
 
         for image_id in image_ids:
-            image = self.images[image_id]
+            image = self.get_images([image_id])
             image_path = self.raw_image_dir / image.file_name
             image_dst_path = image_dir / image.file_name
             io.copy_file(image_path, image_dst_path, create_directory=True)
@@ -58,7 +58,7 @@ def _export_coco(
             image_id = d.pop("image_id")
             coco["images"].append({"id": image_id, **d})
 
-            annotations = self.image_to_annotations[image_id]
+            annotations = self.get_annotations(image_id)
             for annotation in annotations:
                 d = annotation.to_dict()
                 if d.get("segmentation", None):

--- a/waffle_hub/dataset/adapter/transformers.py
+++ b/waffle_hub/dataset/adapter/transformers.py
@@ -33,10 +33,11 @@ def _export_transformers_classification(
         test_ids (list): List of test ids
         unlabeled_ids (list): List of unlabeled ids
     """
+    category_names = self.get_category_names()
     features = Features(
         {
             "image": ImageFeature(),
-            "label": ClassLabel(names=self.category_names),
+            "label": ClassLabel(names=category_names),
         }
     )
 
@@ -46,7 +47,7 @@ def _export_transformers_classification(
             image_path = self.raw_image_dir / image.file_name
             yield {
                 "image": PIL.Image.open(image_path).convert("RGB"),
-                "label": self.category_names[annotation.category_id - 1],
+                "label": category_names[annotation.category_id - 1],
             }
 
     dataset = {}
@@ -82,6 +83,7 @@ def _export_transformers_detection(
         test_ids (list): List of test ids
         unlabeled_ids (list): List of unlabeled ids
     """
+    category_names = self.get_category_names()
     features = Features(
         {
             "image": ImageFeature(),
@@ -92,7 +94,7 @@ def _export_transformers_detection(
                 {
                     "id": Value("int32"),
                     "area": Value("int32"),
-                    "category": ClassLabel(names=self.category_names),
+                    "category": ClassLabel(names=category_names),
                     "bbox": Sequence(Value("float32")),
                 }
             ),
@@ -109,7 +111,7 @@ def _export_transformers_detection(
                     {
                         "id": annotation.annotation_id,
                         "area": annotation.area,
-                        "category": self.category_names[annotation.category_id - 1],
+                        "category": category_names[annotation.category_id - 1],
                         "bbox": annotation.bbox,
                     }
                 )

--- a/waffle_hub/dataset/adapter/yolo.py
+++ b/waffle_hub/dataset/adapter/yolo.py
@@ -5,6 +5,7 @@ from typing import Union
 from waffle_utils.file import io
 
 from waffle_hub import TaskType
+from waffle_hub.dataset import Dataset
 from waffle_hub.schema.fields.image import Image
 from waffle_hub.utils.conversion import merge_multi_segment
 
@@ -19,7 +20,7 @@ def _check_valid_file_paths(images: list[Image]) -> bool:
     Returns:
         bool: True if valid
     """
-    for image in images.values():
+    for image in images:
         file_path = Path(image.file_name)
         if "images" in file_path.parts:
             raise ValueError(
@@ -62,11 +63,10 @@ def _export_yolo_classification(
         split_dir = export_dir / split
         io.make_directory(split_dir)
 
-        for image_id in image_ids:
-            image = self.images[image_id]
+        for image in self.get_images(image_ids):
             image_path = self.raw_image_dir / image.file_name
 
-            annotations = self.get_annotations(image_id)
+            annotations = self.get_annotations(image.image_id)
             if len(annotations) > 1:
                 warnings.warn(f"Multi label does not support yet. Skipping {image_path}.")
                 continue
@@ -77,7 +77,7 @@ def _export_yolo_classification(
 
 
 def _export_yolo_detection(
-    self,
+    self: "Dataset",
     export_dir: Path,
     train_ids: list,
     val_ids: list,
@@ -135,7 +135,7 @@ def _export_yolo_detection(
 
 
 def _export_yolo_segmentation(
-    self,
+    self: "Dataset",
     export_dir: Path,
     train_ids: list,
     val_ids: list,
@@ -196,7 +196,7 @@ def export_yolo(self, export_dir: Union[str, Path]) -> str:
     Returns:
         str: Path to export directory
     """
-    _check_valid_file_paths(self.images)
+    _check_valid_file_paths(self.get_images())
 
     export_dir = Path(export_dir)
 

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -3,7 +3,7 @@ import logging
 import random
 import shutil
 import warnings
-from collections import Counter, OrderedDict, defaultdict
+from collections import Counter, OrderedDict
 from functools import cached_property
 from pathlib import Path
 from tempfile import mkdtemp
@@ -194,7 +194,7 @@ class Dataset:
 
     @cached_property
     def image_to_annotations(self) -> dict[int, list[Annotation]]:
-        image_to_annotations = defaultdict(list)
+        image_to_annotations = {image_id: [] for image_id in self.images.keys()}
         for annotation in tqdm.tqdm(
             self.annotations.values(), desc="Building image to annotation index"
         ):
@@ -203,7 +203,7 @@ class Dataset:
 
     @cached_property
     def category_to_annotations(self) -> dict[int, list[Annotation]]:
-        category_to_annotations = defaultdict(list)
+        category_to_annotations = {category_id: [] for category_id in self.categories.keys()}
         for annotation in tqdm.tqdm(
             self.annotations.values(), desc="Building category to annotation index"
         ):
@@ -331,7 +331,7 @@ class Dataset:
         task: str,
         image_num: int = 100,
         category_num: int = 10,
-        unlabeld_image_num: int = 0,
+        unlabeled_image_num: int = 0,
         root_dir: str = None,
     ) -> "Dataset":
         """
@@ -443,8 +443,8 @@ class Dataset:
                 ds.add_annotations(annotations)
                 annotation_id += len(annotations)
 
-            if unlabeld_image_num > 0:
-                for image_id in range(image_num + 1, image_num + unlabeld_image_num + 1):
+            if unlabeled_image_num > 0:
+                for image_id in range(image_num + 1, image_num + unlabeled_image_num + 1):
                     file_name = f"image_{image_id}.jpg"
                     ds.add_images(
                         [Image(image_id=image_id, file_name=file_name, width=100, height=100)]
@@ -1432,6 +1432,8 @@ class Dataset:
             annotations (list[Annotation]): list of "Annotation"s
         """
         self.__dict__.pop("annotations", None)
+        self.__dict__.pop("image_to_annotations", None)
+        self.__dict__.pop("images", None)
         for item in annotations:
             if self.task == TaskType.TEXT_RECOGNITION:
                 for char in item.caption:

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -1304,14 +1304,17 @@ class Dataset:
         Returns:
             list[Category]: "Category" list
         """
-        return [
-            Category.from_json(f, self.task)
-            for f in (
-                [self.category_dir / f"{category_id}.json" for category_id in category_ids]
-                if category_ids
-                else self.category_dir.glob("*.json")
-            )
-        ]
+        return sorted(
+            [
+                Category.from_json(f, self.task)
+                for f in (
+                    [self.category_dir / f"{category_id}.json" for category_id in category_ids]
+                    if category_ids
+                    else self.category_dir.glob("*.json")
+                )
+            ],
+            key=lambda x: x.category_id,
+        )
 
     def get_annotations(self, image_id: int = None) -> list[Annotation]:
         """Get "Annotation"s.

--- a/waffle_hub/hub/adapter/autocare_dlt/config.py
+++ b/waffle_hub/hub/adapter/autocare_dlt/config.py
@@ -4,12 +4,14 @@ from waffle_hub.schema.configs import TrainConfig
 MODEL_TYPES = {
     "object_detection": {"YOLOv5": list("sml")},
     "classification": {"Classifier": list("sml")},
+    "text_recognition": {"TextRecognition": list("sml"), "LicencePlateRecognition": list("sml")},
 }
 
 # Backend Specifics
 DATA_TYPE_MAP = {
     "object_detection": "COCODetectionDataset",
     "classification": "COCOClassificationDataset",
+    "text_recognition": "COCOTextRecognitionDataset",
 }
 
 WEIGHT_PATH = {

--- a/waffle_hub/hub/adapter/autocare_dlt/config.py
+++ b/waffle_hub/hub/adapter/autocare_dlt/config.py
@@ -4,14 +4,12 @@ from waffle_hub.schema.configs import TrainConfig
 MODEL_TYPES = {
     "object_detection": {"YOLOv5": list("sml")},
     "classification": {"Classifier": list("sml")},
-    "text_recognition": {"TextRecognition": list("sml"), "LicencePlateRecognition": list("sml")},
 }
 
 # Backend Specifics
 DATA_TYPE_MAP = {
     "object_detection": "COCODetectionDataset",
     "classification": "COCOClassificationDataset",
-    "text_recognition": "COCOTextRecognitionDataset",
 }
 
 WEIGHT_PATH = {


### PR DESCRIPTION
fix cached_property and check non-depulicate category

before:
dataset.category_names #output: ["1","2"]
dataset.add_categories([category]) # new category's name is "3"
dataset.category_names # expect: ["1","2","3"], but result is ["1","2"]

after:
I have removed the cache_property that needs to be updated.
You should use the get function instead.
```
get_category_names()
```