### PR TITLE
Hotfix categories

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -259,24 +259,6 @@ def _dummy(dataset_name, task: TaskType, image_num, category_num, unlabeled_imag
     assert len(dataset.get_images(labeled=False)) == unlabeled_image_num
 
 
-def _total_dummy(
-    dataset_name, task: TaskType, image_num, category_num, unlabeled_image_num, root_dir
-):
-    _dummy(dataset_name, task, image_num, category_num, unlabeled_image_num, root_dir)
-    _load(dataset_name, root_dir)
-    _clone(dataset_name, root_dir)
-    _split(dataset_name, root_dir)
-    _export(dataset_name, task, root_dir)
-
-
-def test_dummy(tmpdir):
-    for task in [TaskType.CLASSIFICATION, TaskType.OBJECT_DETECTION, TaskType.INSTANCE_SEGMENTATION]:
-        _total_dummy(f"dummy_{task}", task, 100, 5, 10, tmpdir)
-
-    with pytest.raises(ValueError):
-        _total_dummy("dummy", TaskType.CLASSIFICATION, 3, 3, 0, tmpdir)
-
-
 # test coco
 def _from_coco(dataset_name, task: TaskType, coco_path, root_dir):
     dataset = Dataset.from_coco(

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -152,217 +152,192 @@ def _total(hub, dataset: Dataset, image_size: int, advance_params: dict = None, 
     _util(hub)
 
 
-# def test_ultralytics_segmentation(instance_segmentation_dataset: Dataset, tmpdir: Path):
-#     image_size = 32
-#     dataset = instance_segmentation_dataset
+def test_ultralytics_segmentation(instance_segmentation_dataset: Dataset, tmpdir: Path):
+    image_size = 32
+    dataset = instance_segmentation_dataset
 
-#     # test hub
-#     name = "test_seg"
-#     hub = Hub.new(
-#         name=name,
-#         backend="ultralytics",
-#         task=TaskType.INSTANCE_SEGMENTATION,
-#         model_type="yolov8",
-#         model_size="n",
-#         categories=dataset.get_category_names(),
-#         root_dir=tmpdir,
-#     )
-#     hub = Hub.load(name=name, root_dir=tmpdir)
-#     hub: Hub = Hub.from_model_config(
-#         name=name + "_from_model_config",
-#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-#         root_dir=tmpdir,
-#     )
+    # test hub
+    name = "test_seg"
+    hub = Hub.new(
+        name=name,
+        backend="ultralytics",
+        task=TaskType.INSTANCE_SEGMENTATION,
+        model_type="yolov8",
+        model_size="n",
+        categories=dataset.get_category_names(),
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
 
-#     _total(hub, dataset, image_size)
-
-
-# def test_ultralytics_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
-#     image_size = 32
-#     dataset = object_detection_dataset
-
-#     # test hub
-#     name = "test_det"
-#     hub = Hub.new(
-#         name=name,
-#         backend="ultralytics",
-#         task=TaskType.OBJECT_DETECTION,
-#         model_type="yolov8",
-#         model_size="n",
-#         categories=dataset.get_category_names(),
-#         root_dir=tmpdir,
-#     )
-#     hub = Hub.load(name=name, root_dir=tmpdir)
-#     hub: Hub = Hub.from_model_config(
-#         name=name + "_from_model_config",
-#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-#         root_dir=tmpdir,
-#     )
-
-#     _total(hub, dataset, image_size)
+    _total(hub, dataset, image_size)
 
 
-# def test_ultralytics_object_detection_advance_params(
-#     object_detection_dataset: Dataset, tmpdir: Path
-# ):
-#     image_size = 32
-#     dataset = object_detection_dataset
+def test_ultralytics_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
+    image_size = 32
+    dataset = object_detection_dataset
 
-#     # test hub
-#     name = "test_det_adv"
-#     hub = Hub.new(
-#         name=name,
-#         backend="ultralytics",
-#         task=TaskType.OBJECT_DETECTION,
-#         model_type="yolov8",
-#         model_size="n",
-#         categories=dataset.get_category_names(),
-#         root_dir=tmpdir,
-#     )
-#     hub = Hub.load(name=name, root_dir=tmpdir)
-#     hub: Hub = Hub.from_model_config(
-#         name=name + "_from_model_config",
-#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-#         root_dir=tmpdir,
-#     )
+    # test hub
+    name = "test_det"
+    hub = Hub.new(
+        name=name,
+        backend="ultralytics",
+        task=TaskType.OBJECT_DETECTION,
+        model_type="yolov8",
+        model_size="n",
+        categories=dataset.get_category_names(),
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
 
-#     hub.get_default_advance_train_params()
-
-#     _total(hub, dataset, image_size, {"box": 4, "cls": 1})
-#     hub.delete_artifact()
-
-#     with open(str(tmpdir / "adv.json"), "w") as f:
-#         json.dump({"box": 4, "cls": 2}, f)
-#     _total(hub, dataset, image_size, str(tmpdir / "adv.json"))
-#     hub.delete_artifact()
-
-#     with pytest.raises(ValueError):
-#         _total(hub, dataset, image_size, {"box": 4, "dummy_adv_param": 2})
+    _total(hub, dataset, image_size)
 
 
-# def test_ultralytics_classification(classification_dataset: Dataset, tmpdir: Path):
-#     image_size = 32
-#     dataset = classification_dataset
+def test_ultralytics_object_detection_advance_params(
+    object_detection_dataset: Dataset, tmpdir: Path
+):
+    image_size = 32
+    dataset = object_detection_dataset
 
-#     # test hub
-#     name = "test_cls"
-#     hub = Hub.new(
-#         name=name,
-#         backend="ultralytics",
-#         task=TaskType.CLASSIFICATION,
-#         model_type="yolov8",
-#         model_size="n",
-#         categories=classification_dataset.get_category_names(),
-#         root_dir=tmpdir,
-#     )
-#     hub = Hub.load(name=name, root_dir=tmpdir)
-#     hub: Hub = Hub.from_model_config(
-#         name=name + "_from_model_config",
-#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-#         root_dir=tmpdir,
-#     )
+    # test hub
+    name = "test_det_adv"
+    hub = Hub.new(
+        name=name,
+        backend="ultralytics",
+        task=TaskType.OBJECT_DETECTION,
+        model_type="yolov8",
+        model_size="n",
+        categories=dataset.get_category_names(),
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
 
-#     _total(hub, dataset, image_size)
+    hub.get_default_advance_train_params()
 
+    _total(hub, dataset, image_size, {"box": 4, "cls": 1})
+    hub.delete_artifact()
 
-# def test_transformers_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
-#     image_size = 32
-#     dataset = object_detection_dataset
+    with open(str(tmpdir / "adv.json"), "w") as f:
+        json.dump({"box": 4, "cls": 2}, f)
+    _total(hub, dataset, image_size, str(tmpdir / "adv.json"))
+    hub.delete_artifact()
 
-#     # test hub
-#     name = "test_det"
-#     hub = Hub.new(
-#         name=name,
-#         backend="transformers",
-#         task=TaskType.OBJECT_DETECTION,
-#         model_type="YOLOS",
-#         model_size="tiny",
-#         categories=object_detection_dataset.get_category_names(),
-#         root_dir=tmpdir,
-#     )
-#     hub = Hub.load(name=name, root_dir=tmpdir)
-#     hub: Hub = Hub.from_model_config(
-#         name=name + "_from_model_config",
-#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-#         root_dir=tmpdir,
-#     )
-
-#     _total(hub, dataset, image_size)
+    with pytest.raises(ValueError):
+        _total(hub, dataset, image_size, {"box": 4, "dummy_adv_param": 2})
 
 
-# def test_transformers_classification(classification_dataset: Dataset, tmpdir: Path):
-#     image_size = 224
-#     dataset = classification_dataset
+def test_ultralytics_classification(classification_dataset: Dataset, tmpdir: Path):
+    image_size = 32
+    dataset = classification_dataset
 
-#     # test hub
-#     name = "test_cls"
-#     hub = Hub.new(
-#         name=name,
-#         backend="transformers",
-#         task=TaskType.CLASSIFICATION,
-#         model_type="ViT",
-#         model_size="tiny",
-#         categories=classification_dataset.get_category_names(),
-#         root_dir=tmpdir,
-#     )
-#     hub = Hub.load(name=name, root_dir=tmpdir)
-#     hub: Hub = Hub.from_model_config(
-#         name=name + "_from_model_config",
-#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-#         root_dir=tmpdir,
-#     )
+    # test hub
+    name = "test_cls"
+    hub = Hub.new(
+        name=name,
+        backend="ultralytics",
+        task=TaskType.CLASSIFICATION,
+        model_type="yolov8",
+        model_size="n",
+        categories=classification_dataset.get_category_names(),
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
 
-#     _total(hub, dataset, image_size)
-
-
-# def test_non_hold(classification_dataset: Dataset, tmpdir: Path):
-#     image_size = 32
-#     dataset = classification_dataset
-
-#     # test hub
-#     name = "test_cls"
-#     hub = Hub.new(
-#         name=name,
-#         backend="ultralytics",
-#         task=TaskType.CLASSIFICATION,
-#         model_type="yolov8",
-#         model_size="n",
-#         categories=classification_dataset.get_category_names(),
-#         root_dir=tmpdir,
-#     )
-#     hub = Hub.load(name=name, root_dir=tmpdir)
-#     hub: Hub = Hub.from_model_config(
-#         name=name + "_from_model_config",
-#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-#         root_dir=tmpdir,
-#     )
-
-#     _total(hub, dataset, image_size, hold=False)
+    _total(hub, dataset, image_size)
 
 
-# def test_autocare_dlt_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
-#     image_size = 32
-#     dataset = object_detection_dataset
+def test_transformers_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
+    image_size = 32
+    dataset = object_detection_dataset
 
-#     # test hub
-#     name = "test_det"
-#     hub = Hub.new(
-#         name=name,
-#         backend="autocare_dlt",
-#         task=TaskType.OBJECT_DETECTION,
-#         model_type="YOLOv5",
-#         model_size="s",
-#         categories=object_detection_dataset.get_category_names(),
-#         root_dir=tmpdir,
-#     )
-#     hub = Hub.load(name=name, root_dir=tmpdir)
-#     hub: Hub = Hub.from_model_config(
-#         name=name + "_from_model_config",
-#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-#         root_dir=tmpdir,
-#     )
+    # test hub
+    name = "test_det"
+    hub = Hub.new(
+        name=name,
+        backend="transformers",
+        task=TaskType.OBJECT_DETECTION,
+        model_type="YOLOS",
+        model_size="tiny",
+        categories=object_detection_dataset.get_category_names(),
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
 
-#     _total(hub, dataset, image_size)
+    _total(hub, dataset, image_size)
+
+
+def test_non_hold(classification_dataset: Dataset, tmpdir: Path):
+    image_size = 32
+    dataset = classification_dataset
+
+    # test hub
+    name = "test_cls"
+    hub = Hub.new(
+        name=name,
+        backend="ultralytics",
+        task=TaskType.CLASSIFICATION,
+        model_type="yolov8",
+        model_size="n",
+        categories=classification_dataset.get_category_names(),
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
+
+    _total(hub, dataset, image_size, hold=False)
+
+
+def test_autocare_dlt_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
+    image_size = 32
+    dataset = object_detection_dataset
+
+    # test hub
+    name = "test_det"
+    hub = Hub.new(
+        name=name,
+        backend="autocare_dlt",
+        task=TaskType.OBJECT_DETECTION,
+        model_type="YOLOv5",
+        model_size="s",
+        categories=object_detection_dataset.get_category_names(),
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
+
+    _total(hub, dataset, image_size)
 
 
 def test_autocare_dlt_classification(classification_dataset: Dataset, tmpdir: Path):
@@ -377,7 +352,7 @@ def test_autocare_dlt_classification(classification_dataset: Dataset, tmpdir: Pa
         task=TaskType.CLASSIFICATION,
         model_type="Classifier",
         model_size="s",
-        categories=dataset.get_category_names(),
+        categories=dataset.get_categories(),
         root_dir=tmpdir,
     )
     hub = Hub.load(name=name, root_dir=tmpdir)
@@ -402,7 +377,82 @@ def test_autocare_dlt_text_recognition(text_recognition_dataset: Dataset, tmpdir
         task=TaskType.TEXT_RECOGNITION,
         model_type="TextRecognition",
         model_size="s",
-        categories=dataset.get_category_names(),
+        categories=dataset.get_categories(),
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
+
+    _total(hub, dataset, image_size)
+
+
+def test_ultralytics_classification_without_category(classification_dataset: Dataset, tmpdir: Path):
+    image_size = 32
+    dataset = classification_dataset
+
+    # test hub
+    name = "test_cls"
+    hub = Hub.new(
+        name=name,
+        backend="ultralytics",
+        task=TaskType.CLASSIFICATION,
+        model_type="yolov8",
+        model_size="n",
+        # categories=classification_dataset.get_category_names(),  # auto detect
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
+
+    _total(hub, dataset, image_size)
+
+
+def test_autocare_dlt_classification_without_category(classification_dataset: Dataset, tmpdir: Path):
+    image_size = 32
+    dataset = classification_dataset
+
+    # test hub
+    name = "test_cls"
+    hub = Hub.new(
+        name=name,
+        backend="autocare_dlt",
+        task=TaskType.CLASSIFICATION,
+        model_type="Classifier",
+        model_size="s",
+        # categories=dataset.get_categories(),
+        root_dir=tmpdir,
+    )
+    hub = Hub.load(name=name, root_dir=tmpdir)
+    hub: Hub = Hub.from_model_config(
+        name=name + "_from_model_config",
+        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+        root_dir=tmpdir,
+    )
+
+    _total(hub, dataset, image_size)
+
+
+def test_transformers_classification(classification_dataset: Dataset, tmpdir: Path):
+    image_size = 224
+    dataset = classification_dataset
+
+    # test hub
+    name = "test_cls"
+    hub = Hub.new(
+        name=name,
+        backend="transformers",
+        task=TaskType.CLASSIFICATION,
+        model_type="ViT",
+        model_size="tiny",
+        # categories=classification_dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = Hub.load(name=name, root_dir=tmpdir)

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -152,234 +152,222 @@ def _total(hub, dataset: Dataset, image_size: int, advance_params: dict = None, 
     _util(hub)
 
 
-def test_ultralytics_segmentation(instance_segmentation_dataset: Dataset, tmpdir: Path):
-    image_size = 32
-    dataset = instance_segmentation_dataset
+# def test_ultralytics_segmentation(instance_segmentation_dataset: Dataset, tmpdir: Path):
+#     image_size = 32
+#     dataset = instance_segmentation_dataset
 
-    # test hub
-    name = "test_seg"
-    hub = Hub.new(
-        name=name,
-        backend="ultralytics",
-        task=TaskType.INSTANCE_SEGMENTATION,
-        model_type="yolov8",
-        model_size="n",
-        categories=dataset.get_category_names(),
-        root_dir=tmpdir,
-    )
-    hub = Hub.load(name=name, root_dir=tmpdir)
-    hub: Hub = Hub.from_model_config(
-        name=name + "_from_model_config",
-        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-        root_dir=tmpdir,
-    )
+#     # test hub
+#     name = "test_seg"
+#     hub = Hub.new(
+#         name=name,
+#         backend="ultralytics",
+#         task=TaskType.INSTANCE_SEGMENTATION,
+#         model_type="yolov8",
+#         model_size="n",
+#         categories=dataset.get_category_names(),
+#         root_dir=tmpdir,
+#     )
+#     hub = Hub.load(name=name, root_dir=tmpdir)
+#     hub: Hub = Hub.from_model_config(
+#         name=name + "_from_model_config",
+#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+#         root_dir=tmpdir,
+#     )
 
-    _total(hub, dataset, image_size)
-
-
-def test_ultralytics_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
-    image_size = 32
-    dataset = object_detection_dataset
-
-    # test hub
-    name = "test_det"
-    hub = Hub.new(
-        name=name,
-        backend="ultralytics",
-        task=TaskType.OBJECT_DETECTION,
-        model_type="yolov8",
-        model_size="n",
-        categories=dataset.get_category_names(),
-        root_dir=tmpdir,
-    )
-    hub = Hub.load(name=name, root_dir=tmpdir)
-    hub: Hub = Hub.from_model_config(
-        name=name + "_from_model_config",
-        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-        root_dir=tmpdir,
-    )
-
-    _total(hub, dataset, image_size)
+#     _total(hub, dataset, image_size)
 
 
-def test_ultralytics_object_detection_advance_params(
-    object_detection_dataset: Dataset, tmpdir: Path
-):
-    image_size = 32
-    dataset = object_detection_dataset
+# def test_ultralytics_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
+#     image_size = 32
+#     dataset = object_detection_dataset
 
-    # test hub
-    name = "test_det_adv"
-    hub = Hub.new(
-        name=name,
-        backend="ultralytics",
-        task=TaskType.OBJECT_DETECTION,
-        model_type="yolov8",
-        model_size="n",
-        categories=dataset.get_category_names(),
-        root_dir=tmpdir,
-    )
-    hub = Hub.load(name=name, root_dir=tmpdir)
-    hub: Hub = Hub.from_model_config(
-        name=name + "_from_model_config",
-        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-        root_dir=tmpdir,
-    )
+#     # test hub
+#     name = "test_det"
+#     hub = Hub.new(
+#         name=name,
+#         backend="ultralytics",
+#         task=TaskType.OBJECT_DETECTION,
+#         model_type="yolov8",
+#         model_size="n",
+#         categories=dataset.get_category_names(),
+#         root_dir=tmpdir,
+#     )
+#     hub = Hub.load(name=name, root_dir=tmpdir)
+#     hub: Hub = Hub.from_model_config(
+#         name=name + "_from_model_config",
+#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+#         root_dir=tmpdir,
+#     )
 
-    hub.get_default_advance_train_params()
-
-    _total(hub, dataset, image_size, {"box": 4, "cls": 1})
-    hub.delete_artifact()
-
-    with open(str(tmpdir / "adv.json"), "w") as f:
-        json.dump({"box": 4, "cls": 2}, f)
-    _total(hub, dataset, image_size, str(tmpdir / "adv.json"))
-    hub.delete_artifact()
-
-    with pytest.raises(ValueError):
-        _total(hub, dataset, image_size, {"box": 4, "dummy_adv_param": 2})
+#     _total(hub, dataset, image_size)
 
 
-def test_ultralytics_classification(classification_dataset: Dataset, tmpdir: Path):
-    image_size = 32
-    dataset = classification_dataset
+# def test_ultralytics_object_detection_advance_params(
+#     object_detection_dataset: Dataset, tmpdir: Path
+# ):
+#     image_size = 32
+#     dataset = object_detection_dataset
 
-    # test hub
-    name = "test_cls"
-    hub = Hub.new(
-        name=name,
-        backend="ultralytics",
-        task=TaskType.CLASSIFICATION,
-        model_type="yolov8",
-        model_size="n",
-        categories=classification_dataset.get_category_names(),
-        root_dir=tmpdir,
-    )
-    hub = Hub.load(name=name, root_dir=tmpdir)
-    hub: Hub = Hub.from_model_config(
-        name=name + "_from_model_config",
-        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-        root_dir=tmpdir,
-    )
+#     # test hub
+#     name = "test_det_adv"
+#     hub = Hub.new(
+#         name=name,
+#         backend="ultralytics",
+#         task=TaskType.OBJECT_DETECTION,
+#         model_type="yolov8",
+#         model_size="n",
+#         categories=dataset.get_category_names(),
+#         root_dir=tmpdir,
+#     )
+#     hub = Hub.load(name=name, root_dir=tmpdir)
+#     hub: Hub = Hub.from_model_config(
+#         name=name + "_from_model_config",
+#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+#         root_dir=tmpdir,
+#     )
 
-    _total(hub, dataset, image_size)
+#     hub.get_default_advance_train_params()
 
+#     _total(hub, dataset, image_size, {"box": 4, "cls": 1})
+#     hub.delete_artifact()
 
-def test_transformers_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
-    image_size = 32
-    dataset = object_detection_dataset
+#     with open(str(tmpdir / "adv.json"), "w") as f:
+#         json.dump({"box": 4, "cls": 2}, f)
+#     _total(hub, dataset, image_size, str(tmpdir / "adv.json"))
+#     hub.delete_artifact()
 
-    # test hub
-    name = "test_det"
-    hub = Hub.new(
-        name=name,
-        backend="transformers",
-        task=TaskType.OBJECT_DETECTION,
-        model_type="YOLOS",
-        model_size="tiny",
-        categories=object_detection_dataset.get_category_names(),
-        root_dir=tmpdir,
-    )
-    hub = Hub.load(name=name, root_dir=tmpdir)
-    hub: Hub = Hub.from_model_config(
-        name=name + "_from_model_config",
-        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-        root_dir=tmpdir,
-    )
-
-    _total(hub, dataset, image_size)
+#     with pytest.raises(ValueError):
+#         _total(hub, dataset, image_size, {"box": 4, "dummy_adv_param": 2})
 
 
-def test_transformers_classification(classification_dataset: Dataset, tmpdir: Path):
-    image_size = 224
-    dataset = classification_dataset
+# def test_ultralytics_classification(classification_dataset: Dataset, tmpdir: Path):
+#     image_size = 32
+#     dataset = classification_dataset
 
-    # test hub
-    name = "test_cls"
-    hub = Hub.new(
-        name=name,
-        backend="transformers",
-        task=TaskType.CLASSIFICATION,
-        model_type="ViT",
-        model_size="tiny",
-        categories=classification_dataset.get_category_names(),
-        root_dir=tmpdir,
-    )
-    hub = Hub.load(name=name, root_dir=tmpdir)
-    hub: Hub = Hub.from_model_config(
-        name=name + "_from_model_config",
-        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-        root_dir=tmpdir,
-    )
+#     # test hub
+#     name = "test_cls"
+#     hub = Hub.new(
+#         name=name,
+#         backend="ultralytics",
+#         task=TaskType.CLASSIFICATION,
+#         model_type="yolov8",
+#         model_size="n",
+#         categories=classification_dataset.get_category_names(),
+#         root_dir=tmpdir,
+#     )
+#     hub = Hub.load(name=name, root_dir=tmpdir)
+#     hub: Hub = Hub.from_model_config(
+#         name=name + "_from_model_config",
+#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+#         root_dir=tmpdir,
+#     )
 
-    _total(hub, dataset, image_size)
-
-
-def test_non_hold(classification_dataset: Dataset, tmpdir: Path):
-    image_size = 32
-    dataset = classification_dataset
-
-    # test hub
-    name = "test_cls"
-    hub = Hub.new(
-        name=name,
-        backend="ultralytics",
-        task=TaskType.CLASSIFICATION,
-        model_type="yolov8",
-        model_size="n",
-        categories=classification_dataset.get_category_names(),
-        root_dir=tmpdir,
-    )
-    hub = Hub.load(name=name, root_dir=tmpdir)
-    hub: Hub = Hub.from_model_config(
-        name=name + "_from_model_config",
-        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-        root_dir=tmpdir,
-    )
-
-    _total(hub, dataset, image_size, hold=False)
+#     _total(hub, dataset, image_size)
 
 
-def test_autocare_dlt_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
-    image_size = 32
-    dataset = object_detection_dataset
+# def test_transformers_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
+#     image_size = 32
+#     dataset = object_detection_dataset
 
-    # test hub
-    name = "test_det"
-    hub = Hub.new(
-        name=name,
-        backend="autocare_dlt",
-        task=TaskType.OBJECT_DETECTION,
-        model_type="YOLOv5",
-        model_size="s",
-        categories=object_detection_dataset.get_category_names(),
-        root_dir=tmpdir,
-    )
-    hub = Hub.load(name=name, root_dir=tmpdir)
-    hub: Hub = Hub.from_model_config(
-        name=name + "_from_model_config",
-        model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
-        root_dir=tmpdir,
-    )
+#     # test hub
+#     name = "test_det"
+#     hub = Hub.new(
+#         name=name,
+#         backend="transformers",
+#         task=TaskType.OBJECT_DETECTION,
+#         model_type="YOLOS",
+#         model_size="tiny",
+#         categories=object_detection_dataset.get_category_names(),
+#         root_dir=tmpdir,
+#     )
+#     hub = Hub.load(name=name, root_dir=tmpdir)
+#     hub: Hub = Hub.from_model_config(
+#         name=name + "_from_model_config",
+#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+#         root_dir=tmpdir,
+#     )
 
-    _total(hub, dataset, image_size)
+#     _total(hub, dataset, image_size)
+
+
+# def test_transformers_classification(classification_dataset: Dataset, tmpdir: Path):
+#     image_size = 224
+#     dataset = classification_dataset
+
+#     # test hub
+#     name = "test_cls"
+#     hub = Hub.new(
+#         name=name,
+#         backend="transformers",
+#         task=TaskType.CLASSIFICATION,
+#         model_type="ViT",
+#         model_size="tiny",
+#         categories=classification_dataset.get_category_names(),
+#         root_dir=tmpdir,
+#     )
+#     hub = Hub.load(name=name, root_dir=tmpdir)
+#     hub: Hub = Hub.from_model_config(
+#         name=name + "_from_model_config",
+#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+#         root_dir=tmpdir,
+#     )
+
+#     _total(hub, dataset, image_size)
+
+
+# def test_non_hold(classification_dataset: Dataset, tmpdir: Path):
+#     image_size = 32
+#     dataset = classification_dataset
+
+#     # test hub
+#     name = "test_cls"
+#     hub = Hub.new(
+#         name=name,
+#         backend="ultralytics",
+#         task=TaskType.CLASSIFICATION,
+#         model_type="yolov8",
+#         model_size="n",
+#         categories=classification_dataset.get_category_names(),
+#         root_dir=tmpdir,
+#     )
+#     hub = Hub.load(name=name, root_dir=tmpdir)
+#     hub: Hub = Hub.from_model_config(
+#         name=name + "_from_model_config",
+#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+#         root_dir=tmpdir,
+#     )
+
+#     _total(hub, dataset, image_size, hold=False)
+
+
+# def test_autocare_dlt_object_detection(object_detection_dataset: Dataset, tmpdir: Path):
+#     image_size = 32
+#     dataset = object_detection_dataset
+
+#     # test hub
+#     name = "test_det"
+#     hub = Hub.new(
+#         name=name,
+#         backend="autocare_dlt",
+#         task=TaskType.OBJECT_DETECTION,
+#         model_type="YOLOv5",
+#         model_size="s",
+#         categories=object_detection_dataset.get_category_names(),
+#         root_dir=tmpdir,
+#     )
+#     hub = Hub.load(name=name, root_dir=tmpdir)
+#     hub: Hub = Hub.from_model_config(
+#         name=name + "_from_model_config",
+#         model_config_file=tmpdir / name / Hub.MODEL_CONFIG_FILE,
+#         root_dir=tmpdir,
+#     )
+
+#     _total(hub, dataset, image_size)
 
 
 def test_autocare_dlt_classification(classification_dataset: Dataset, tmpdir: Path):
     image_size = 32
     dataset = classification_dataset
-
-    # temporal solution
-    super_cat = [[c.supercategory, c.name] for c in dataset.get_categories()]
-    super_cat_dict = {}
-    for super_cat, cat in super_cat:
-        if super_cat not in super_cat_dict:
-            super_cat_dict[super_cat] = []
-        super_cat_dict[super_cat].append(cat)
-    super_cat_dict_list = []
-
-    for super_cat, cat in super_cat_dict.items():
-        super_cat_dict_list.append({super_cat: cat})
 
     # test hub
     name = "test_cls"
@@ -389,7 +377,7 @@ def test_autocare_dlt_classification(classification_dataset: Dataset, tmpdir: Pa
         task=TaskType.CLASSIFICATION,
         model_type="Classifier",
         model_size="s",
-        categories=super_cat_dict_list,
+        categories=dataset.get_category_names(),
         root_dir=tmpdir,
     )
     hub = Hub.load(name=name, root_dir=tmpdir)

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -68,7 +68,8 @@ class Dataset:
 
         if not self.initialized():
             self.initialize()
-        self.set_categories(categories)
+            self.set_categories(categories)
+            self.save_dataset_info()
 
     def __repr__(self):
         return self.get_dataset_info().__repr__()
@@ -99,7 +100,7 @@ class Dataset:
         return self.get_categories()
 
     def set_categories(self, v):
-        if v is None:
+        if v is None or len(v) == 0:
             v = []
         elif isinstance(v[0], dict):
             v = [
@@ -206,7 +207,7 @@ class Dataset:
         return self.set_dir / Dataset.UNLABELED_SET_FILE_NAME
 
     def get_category_names(self) -> list[str]:
-        return [c.name for c in sorted(self.get_categories(), key=lambda c: c.category_id)]
+        return [category.name for category in self.categories]
 
     def get_image_to_annotations(self) -> dict[int, list[Annotation]]:
         image_to_annotations = defaultdict(list)
@@ -333,6 +334,7 @@ class Dataset:
 
         ds = Dataset.new(name=name, task=src_ds.task, root_dir=root_dir)
         io.copy_files_to_directory(src_ds.dataset_dir, ds.dataset_dir, create_directory=True)
+        ds.save_dataset_info()
 
         return ds
 
@@ -1294,14 +1296,6 @@ class Dataset:
         io.make_directory(self.image_dir)
         io.make_directory(self.annotation_dir)
         io.make_directory(self.category_dir)
-
-        # create dataset_info.yaml
-        io.save_yaml(
-            DatasetInfo(
-                name=self.name, task=self.task, categories=self.categories, created=self.created
-            ).to_dict(),
-            self.dataset_info_file,
-        )
 
     def initialized(self) -> bool:
         """Check if Dataset has been initialized or not.

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -70,6 +70,8 @@ class Dataset:
             self.initialize()
             self.set_categories(categories)
             self.save_dataset_info()
+        else:  # for backward compatibility
+            self.save_dataset_info()
 
     def __repr__(self):
         return self.get_dataset_info().__repr__()

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -296,7 +296,13 @@ class Dataset:
         Returns:
             Dataset: Dataset Class
         """
-        return cls(name=name, task=task, categories=categories, root_dir=root_dir)
+        root_dir = Dataset.parse_root_dir(root_dir)
+        try:
+            return cls(name=name, task=task, categories=categories, root_dir=root_dir)
+        except Exception as e:
+            if (root_dir / name).exists():
+                io.remove_directory(root_dir / name)
+            raise e
 
     @classmethod
     def clone(
@@ -332,13 +338,20 @@ class Dataset:
         Returns:
             Dataset: Dataset Class
         """
-        src_ds = Dataset.load(src_name, src_root_dir)
+        root_dir = Dataset.parse_root_dir(root_dir)
 
-        ds = Dataset.new(name=name, task=src_ds.task, root_dir=root_dir)
-        io.copy_files_to_directory(src_ds.dataset_dir, ds.dataset_dir, create_directory=True)
-        ds.save_dataset_info()
+        try:
+            src_ds = Dataset.load(src_name, src_root_dir)
 
-        return ds
+            ds = Dataset.new(name=name, task=src_ds.task, root_dir=root_dir)
+            io.copy_files_to_directory(src_ds.dataset_dir, ds.dataset_dir, create_directory=True)
+            ds.save_dataset_info()
+
+            return ds
+        except Exception as e:
+            if (root_dir / name).exists():
+                io.remove_directory(root_dir / name)
+            raise e
 
     @classmethod
     def dummy(

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -56,6 +56,7 @@ class Dataset:
         self,
         name: str,
         task: Union[str, TaskType],
+        categories: list[Union[str, int, float, dict, Category]] = None,
         created: str = None,
         root_dir: str = None,
     ):
@@ -64,6 +65,10 @@ class Dataset:
         self.created = created
 
         self.root_dir = root_dir
+
+        if not self.initialized():
+            self.initialize()
+        self.set_categories(categories)
 
     def __repr__(self):
         return self.get_dataset_info().__repr__()
@@ -88,6 +93,37 @@ class Dataset:
         if v not in TaskType:
             raise ValueError(f"Invalid task type: {v}" f"Available task types: {list(TaskType)}")
         self.__task = v
+
+    @property
+    def categories(self) -> list[Category]:
+        return self.get_categories()
+
+    def set_categories(self, v):
+        if v is None:
+            v = []
+        elif isinstance(v[0], dict):
+            v = [
+                getattr(Category, self.task.lower())(
+                    **{
+                        **category,
+                        "category_id": category.get("category_id", i),
+                    }
+                )
+                for i, category in enumerate(v, start=1)
+            ]
+        elif isinstance(v[0], (str, int, float)):
+            v = [
+                getattr(Category, self.task.lower())(
+                    category_id=i,
+                    supercategory="object",
+                    name=str(category),
+                )
+                for i, category in enumerate(v, start=1)
+            ]
+        elif isinstance(v[0], Category):
+            pass
+
+        self.add_categories(v)
 
     @property
     def created(self):
@@ -226,7 +262,13 @@ class Dataset:
 
     # factories
     @classmethod
-    def new(cls, name: str, task: str, root_dir: str = None) -> "Dataset":
+    def new(
+        cls,
+        name: str,
+        task: str,
+        categories: list[Union[str, int, float, dict, Category]] = None,
+        root_dir: str = None,
+    ) -> "Dataset":
         """
         Create New Dataset.
         This method creates a new dataset directory and initialize dataset info file.
@@ -235,6 +277,7 @@ class Dataset:
         Args:
             name (str): Dataset name
             task (str): Dataset task
+            categories (list[Union[str, int, float, dict, Category]]): Dataset categories
             root_dir (str, optional): Dataset root directory. Defaults to None.
 
         Raises:
@@ -250,13 +293,7 @@ class Dataset:
         Returns:
             Dataset: Dataset Class
         """
-        ds = cls(name=name, task=task, root_dir=root_dir)
-        if ds.initialized():
-            raise FileExistsError(
-                f'{ds.dataset_dir} already exists. try another name or Dataset.load("{name}")'
-            )
-        ds.initialize()
-        return ds
+        return cls(name=name, task=task, categories=categories, root_dir=root_dir)
 
     @classmethod
     def clone(
@@ -293,12 +330,9 @@ class Dataset:
             Dataset: Dataset Class
         """
         src_ds = Dataset.load(src_name, src_root_dir)
-        if not src_ds.initialized():
-            raise FileNotFoundError(f"{src_ds.dataset_dir} has not been created by Waffle.")
 
-        ds = Dataset.new(name, src_ds.task, root_dir)
+        ds = Dataset.new(name=name, task=src_ds.task, root_dir=root_dir)
         io.copy_files_to_directory(src_ds.dataset_dir, ds.dataset_dir, create_directory=True)
-        ds.initialize()
 
         return ds
 
@@ -333,7 +367,7 @@ class Dataset:
             >>> len(ds.get_categories())
             10
         """
-        ds = Dataset.new(name, task, root_dir)
+        ds = Dataset.new(name=name, task=task, root_dir=root_dir)
 
         try:
             for category_id in range(1, category_num + 1):
@@ -618,8 +652,7 @@ class Dataset:
         Returns:
             Dataset: Dataset Class
         """
-        ds = Dataset.new(name, task, root_dir)
-        ds.initialize()
+        ds = Dataset.new(name=name, task=task, root_dir=root_dir)
 
         if isinstance(coco_file, list) and isinstance(coco_root_dir, list):
             if len(coco_file) != len(coco_root_dir):
@@ -767,8 +800,7 @@ class Dataset:
         Returns:
             Dataset: Dataset Class.
         """
-        ds = Dataset.new(name, task, root_dir)
-        ds.initialize()
+        ds = Dataset.new(name=name, task=task, root_dir=root_dir)
 
         if isinstance(coco_file, list) and isinstance(coco_root_dir, list):
             if len(coco_file) != len(coco_root_dir):
@@ -912,8 +944,7 @@ class Dataset:
             Dataset: Imported dataset.
         """
 
-        ds = Dataset.new(name, task, root_dir)
-        ds.initialize()
+        ds = Dataset(name=name, task=task, root_dir=root_dir)
 
         def _import_classification(set_dir: Path, image_ids: list[int]):
             # categories
@@ -1083,8 +1114,7 @@ class Dataset:
         Returns:
             Dataset: Dataset Class
         """
-        ds = Dataset.new(name, task, root_dir)
-        ds.initialize()
+        ds = Dataset.new(name=name, task=task, root_dir=root_dir)
 
         dataset = load_from_disk(dataset_dir)
 
@@ -1256,6 +1286,10 @@ class Dataset:
         """Initialize Dataset.
         It creates necessary directories under {dataset_root_dir}/{dataset_name}.
         """
+
+        if self.initialized():
+            raise FileExistsError(f"{self.name} is already initialized.")
+
         io.make_directory(self.raw_image_dir)
         io.make_directory(self.image_dir)
         io.make_directory(self.annotation_dir)
@@ -1263,7 +1297,9 @@ class Dataset:
 
         # create dataset_info.yaml
         io.save_yaml(
-            DatasetInfo(name=self.name, task=self.task, created=self.created).to_dict(),
+            DatasetInfo(
+                name=self.name, task=self.task, categories=self.categories, created=self.created
+            ).to_dict(),
             self.dataset_info_file,
         )
 
@@ -1276,6 +1312,15 @@ class Dataset:
                 not initialized -> False
         """
         return self.dataset_info_file.exists()
+
+    def save_dataset_info(self):
+        """Save DatasetInfo."""
+        DatasetInfo(
+            name=self.name,
+            task=self.task,
+            categories=list(map(lambda x: x.to_dict(), self.categories)),
+            created=self.created,
+        ).save_yaml(self.dataset_info_file)
 
     def trainable(self) -> bool:
         """Check if Dataset is trainable or not.
@@ -1317,7 +1362,11 @@ class Dataset:
         Returns:
             DatasetInfo: DatasetInfo
         """
-        return DatasetInfo.load(self.dataset_info_file)
+        dataset_info = DatasetInfo.load(self.dataset_info_file)
+        if not hasattr(dataset_info, "categories"):
+            dataset_info.categories = self.get_categories()
+            self.save_dataset_info()
+        return dataset_info
 
     # get
     def get_images(self, image_ids: list[int] = None, labeled: bool = True) -> list[Image]:
@@ -1435,6 +1484,8 @@ class Dataset:
             item_id = item.category_id
             item_path = self.category_dir / f"{item_id}.json"
             io.save_json(item.to_dict(), item_path)
+
+        self.save_dataset_info()
 
     def add_annotations(self, annotations: list[Annotation]):
         """Add "Annotation"s to dataset.

--- a/waffle_hub/hub/adapter/autocare_dlt/autocare_dlt_hub.py
+++ b/waffle_hub/hub/adapter/autocare_dlt/autocare_dlt_hub.py
@@ -214,7 +214,7 @@ class AutocareDLTHub(Hub):
         io.save_json(data_config, cfg.data_config, create_directory=True)
 
         if self.task == TaskType.CLASSIFICATION:
-            super_cat = [[c["supercategory"], c["name"]] for c in self.categories]
+            super_cat = [[c.supercategory, c.name] for c in self.categories]
             super_cat_dict = {}
             for super_cat, cat in super_cat:
                 if super_cat not in super_cat_dict:
@@ -226,7 +226,7 @@ class AutocareDLTHub(Hub):
                 categories.append({super_cat: cat})
 
         else:
-            categories = self.categories
+            categories = self.get_category_names()
 
         model_config = get_model_config(
             self.model_type,

--- a/waffle_hub/hub/adapter/autocare_dlt/configs/model_cfg.py
+++ b/waffle_hub/hub/adapter/autocare_dlt/configs/model_cfg.py
@@ -96,8 +96,8 @@ def get_model_config(
             "use_model_ema": True,
             "max_epoch": epochs,
             "seed": seed,
-            "classes": get_multi_task_categories(categories),
-            "num_classes": len(categories),
+            "classes": categories,
+            "num_classes": sum([len(list(category.values())[0]) for category in categories]),
         }
 
     elif model_type == "TextRecognition":
@@ -154,18 +154,3 @@ def get_model_config(
         }
     else:
         raise NotImplementedError(f"Model type {model_type} not implemented.")
-
-
-def get_multi_task_categories(categories: list[dict]):
-    multi_task_categories = []
-    cat_dict = {}
-    for category in categories:
-        sup = category["supercategory"]
-        name = category["name"]
-        if sup not in cat_dict:
-            cat_dict[sup] = [name]
-        else:
-            cat_dict[sup].append(name)
-    for k, v in cat_dict.items():
-        multi_task_categories.append({k: v})
-    return multi_task_categories

--- a/waffle_hub/hub/hub.py
+++ b/waffle_hub/hub/hub.py
@@ -36,6 +36,7 @@ from waffle_hub.schema.configs import (
     TrainConfig,
 )
 from waffle_hub.schema.data import ImageInfo
+from waffle_hub.schema.fields import Category
 from waffle_hub.schema.result import (
     EvaluateResult,
     ExportResult,
@@ -485,7 +486,7 @@ class Hub:
         self.__version = v
 
     @property
-    def categories(self) -> list[dict]:
+    def categories(self) -> list[Category]:
         return self.__categories
 
     @categories.setter
@@ -495,6 +496,7 @@ class Hub:
             raise ValueError("Categories must be specified.")
         if not isinstance(v[0], dict):
             v = [{"supercategory": "object", "name": str(n)} for n in v]
+
         self.__categories = v
 
     @cached_property

--- a/waffle_hub/hub/hub.py
+++ b/waffle_hub/hub/hub.py
@@ -283,24 +283,34 @@ class Hub:
         Returns:
             Hub: Hub instance
         """
-        if name in cls.get_hub_list(root_dir):
-            raise ValueError(f"{name} already exists. Try another name.")
+        root_dir = Hub.parse_root_dir(root_dir)
+        try:
+            if name in cls.get_hub_list(root_dir):
+                raise ValueError(f"{name} already exists. Try another name.")
 
-        backend = backend if backend else cls.get_available_backends()[0]
-        task = str(task).upper() if task else cls.get_available_tasks(backend)[0]
-        model_type = model_type if model_type else cls.get_available_model_types(backend, task)[0]
-        model_size = (
-            model_size if model_size else cls.get_available_model_sizes(backend, task, model_type)[0]
-        )
+            backend = backend if backend else cls.get_available_backends()[0]
+            task = str(task).upper() if task else cls.get_available_tasks(backend)[0]
+            model_type = (
+                model_type if model_type else cls.get_available_model_types(backend, task)[0]
+            )
+            model_size = (
+                model_size
+                if model_size
+                else cls.get_available_model_sizes(backend, task, model_type)[0]
+            )
 
-        return cls.get_hub_class(backend)(
-            name=name,
-            task=task,
-            model_type=model_type,
-            model_size=model_size,
-            categories=categories,
-            root_dir=root_dir,
-        )
+            return cls.get_hub_class(backend)(
+                name=name,
+                task=task,
+                model_type=model_type,
+                model_size=model_size,
+                categories=categories,
+                root_dir=root_dir,
+            )
+        except Exception as e:
+            if (root_dir / name).exists():
+                io.remove_directory(root_dir / name)
+            raise e
 
     @classmethod
     def load(cls, name: str, root_dir: str = None) -> "Hub":
@@ -340,17 +350,23 @@ class Hub:
         Returns:
             Hub: New Hub instance
         """
-        if name in cls.get_hub_list(root_dir):
-            raise ValueError(f"{name} already exists. Try another name.")
+        root_dir = Hub.parse_root_dir(root_dir)
+        try:
+            if name in cls.get_hub_list(root_dir):
+                raise ValueError(f"{name} already exists. Try another name.")
 
-        model_config = io.load_yaml(model_config_file)
-        return cls.new(
-            **{
-                **model_config,
-                "name": name,
-                "root_dir": root_dir,
-            }
-        )
+            model_config = io.load_yaml(model_config_file)
+            return cls.new(
+                **{
+                    **model_config,
+                    "name": name,
+                    "root_dir": root_dir,
+                }
+            )
+        except Exception as e:
+            if (root_dir / name).exists():
+                io.remove_directory(root_dir / name)
+            raise e
 
     @classmethod
     def get_hub_list(cls, root_dir: str = None) -> list[str]:

--- a/waffle_hub/hub/hub.py
+++ b/waffle_hub/hub/hub.py
@@ -100,7 +100,7 @@ class Hub:
         task: Union[str, TaskType] = None,
         model_type: str = None,
         model_size: str = None,
-        categories: Union[list[dict], list] = None,
+        categories: list[Union[str, int, float, dict, Category]] = None,
         root_dir: str = None,
     ):
         if self.BACKEND_NAME is None:
@@ -119,31 +119,13 @@ class Hub:
         self.task: str = task
         self.model_type: str = model_type
         self.model_size: str = model_size
-        self.categories: list[dict] = categories
+        self.categories: list[Category] = categories
         self.root_dir: Path = root_dir
 
         self.backend: str = backend
         self.version: str = version
 
-        # check task supports
-        if self.task not in self.MODEL_TYPES:
-            io.remove_directory()
-            raise ValueError(f"{self.task} is not supported with {self.backend}")
-
-        try:
-            # save model config
-            model_config = ModelConfig(
-                name=self.name,
-                backend=self.backend,
-                version=self.version,
-                task=self.task,
-                model_type=self.model_type,
-                model_size=self.model_size,
-                categories=self.categories,
-            )
-            model_config.save_yaml(self.model_config_file)
-        except Exception as e:
-            raise e
+        self.save_model_config()
 
     def __repr__(self):
         return self.get_model_config().__repr__()
@@ -492,10 +474,37 @@ class Hub:
     @categories.setter
     @type_validator(list)
     def categories(self, v):
-        if v is None:
-            raise ValueError("Categories must be specified.")
-        if not isinstance(v[0], dict):
-            v = [{"supercategory": "object", "name": str(n)} for n in v]
+        if v is None or len(v) == 0:
+            warnings.warn(
+                "Categories is not specified.\n"
+                + "It follows the categories of Dataset when the training starts."
+            )
+            v = []
+        elif isinstance(v[0], dict):
+            v = [
+                getattr(Category, self.task.lower())(
+                    **{
+                        **category,
+                        "category_id": category.get("category_id", i),
+                    }
+                )
+                for i, category in enumerate(v, start=1)
+            ]
+        elif isinstance(v[0], (str, int, float)):
+            v = [
+                getattr(Category, self.task.lower())(
+                    category_id=i,
+                    supercategory="object",
+                    name=str(category),
+                )
+                for i, category in enumerate(v, start=1)
+            ]
+            warnings.warn(
+                "Super category is not specified. It may cause unexpected errors in some backends.\n"
+                + "To avoid this warning, please specify category as a list of dictionary or Category"
+            )
+        elif isinstance(v[0], Category):
+            pass
 
         self.__categories = v
 
@@ -603,6 +612,18 @@ class Hub:
         """
         return ModelConfig.load(self.model_config_file)
 
+    def save_model_config(self):
+        """Save ModelConfig."""
+        ModelConfig(
+            name=self.name,
+            backend=self.backend,
+            version=self.version,
+            task=self.task,
+            model_type=self.model_type,
+            model_size=self.model_size,
+            categories=list(map(lambda x: x.to_dict(), self.categories)),
+        ).save_yaml(self.model_config_file)
+
     def get_default_advance_train_params(
         self, task: str = None, model_type: str = None, model_size: str = None
     ) -> dict:
@@ -621,6 +642,12 @@ class Hub:
             dict: Default train advance params
         """
         raise NotImplementedError(f"{self.backend} does not support advance_params argument.")
+
+    def get_categories(self) -> list[Category]:
+        return self.categories
+
+    def get_category_names(self) -> list[str]:
+        return [category.name for category in self.categories]
 
     # get results
     def get_metrics(self) -> list[list[dict]]:
@@ -887,11 +914,23 @@ class Hub:
             else:
                 raise FileNotFoundError(f"Dataset {dataset} is not exist.")
 
+        ## check task match
         if dataset.task.upper() != self.task.upper():
             raise ValueError(
                 f"Dataset task is not matched with hub task. Dataset task: {dataset.task}, Hub task: {self.task}"
             )
 
+        ## check category match
+        if not self.categories:
+            self.categories = dataset.get_categories()
+            self.save_model_config()
+        elif set(dataset.get_category_names()) != set(self.get_category_names()):
+            raise ValueError(
+                "Dataset categories are not matched with hub categories. \n"
+                + f"Dataset categories: {dataset.get_category_names()}, Hub categories: {self.get_category_names()}"
+            )
+
+        ## convert dataset to backend format if not exist
         export_dir = dataset.export_dir / EXPORT_MAP[self.backend.upper()]
         if not export_dir.exists():
             logger.info(f"[Dataset] Exporting dataset to {self.backend} format...")

--- a/waffle_hub/schema/base_schema.py
+++ b/waffle_hub/schema/base_schema.py
@@ -44,3 +44,6 @@ class BaseSchema:
         elif load_path.suffix == ".yaml":
             config = io.load_yaml(load_path)
         return cls(**config)
+
+    def __getitem__(self, key):
+        return getattr(self, key)

--- a/waffle_hub/schema/data.py
+++ b/waffle_hub/schema/data.py
@@ -1,12 +1,16 @@
 from dataclasses import dataclass
 
-from waffle_hub.schema.base_schema import BaseSchema
 from waffle_utils.log import datetime_now
+
+from waffle_hub.schema.base_schema import BaseSchema
+from waffle_hub.schema.fields import Category
+
 
 @dataclass
 class DatasetInfo(BaseSchema):
     name: str
     task: str
+    categories: list[Category] = None
     created: str = None
 
     def __post_init__(self):

--- a/waffle_hub/schema/fields/base_field.py
+++ b/waffle_hub/schema/fields/base_field.py
@@ -51,3 +51,6 @@ class BaseField(ABC):
         """
         d: dict = io.load_json(f)
         return cls.from_dict(d, task)
+
+    def __getitem__(self, key):
+        return getattr(self, key)

--- a/waffle_hub/schema/fields/base_field.py
+++ b/waffle_hub/schema/fields/base_field.py
@@ -9,6 +9,12 @@ class BaseField(ABC):
     def __init__(self):
         pass
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({', '.join([f'{k}={v}' for k, v in self.to_dict().items()])})"
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
     @abstractmethod
     def to_dict(self):
         pass


### PR DESCRIPTION
- hub can be created without categories
  - categories will be confirmed when train starts.
  - (TODO) if user specified the categories, model should reflect it.
    - refer ultralytics get_model function
- some backends (like autocare_dlt) are dependent on supercategory names.
  - we recommend to use dataset.categories as categories argument of hub.new or just not specifying it.