### PR TITLE
When creating Hub/Dataset new, it now checks if it already exists

### DIFF
--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -345,6 +345,10 @@ class Dataset:
             Dataset: Dataset Class
         """
         root_dir = Dataset.parse_root_dir(root_dir)
+
+        if name in Dataset.get_dataset_list(root_dir):
+            raise FileExistsError(f"Dataset {name} already exists.")
+
         try:
             return cls(name=name, task=task, categories=categories, root_dir=root_dir)
         except Exception as e:

--- a/waffle_hub/hub/hub.py
+++ b/waffle_hub/hub/hub.py
@@ -288,10 +288,11 @@ class Hub:
             Hub: Hub instance
         """
         root_dir = Hub.parse_root_dir(root_dir)
-        try:
-            if name in cls.get_hub_list(root_dir):
-                raise ValueError(f"{name} already exists. Try another name.")
 
+        if name in cls.get_hub_list(root_dir):
+            raise FileExistsError(f"{name} already exists. Try another name.")
+
+        try:
             backend = backend if backend else cls.get_available_backends()[0]
             task = str(task).upper() if task else cls.get_available_tasks(backend)[0]
             model_type = (


### PR DESCRIPTION
When creating Hub/Dataset new, it now checks if it already exists

and  

fixed the bug that existing dir are deleted when creating Hub new.