### PR TITLE
Hotfix import dataset

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,7 @@ def instance_segmentation_dataset(coco_path: Path, tmpdir: Path):
         coco_root_dir=coco_path / "images",
         root_dir=tmpdir,
     )
-    dataset.split(0.2, 0.2, 0.6)
+    dataset.split(0.2, 0.8)
 
     return dataset
 
@@ -114,7 +114,7 @@ def object_detection_dataset(coco_path: Path, tmpdir: Path):
         coco_root_dir=coco_path / "images",
         root_dir=tmpdir,
     )
-    dataset.split(0.2, 0.2, 0.6)
+    dataset.split(0.2, 0.8)
 
     return dataset
 
@@ -128,7 +128,7 @@ def classification_dataset(coco_path: Path, tmpdir: Path):
         coco_root_dir=coco_path / "images",
         root_dir=tmpdir,
     )
-    dataset.split(0.2, 0.2, 0.6)
+    dataset.split(0.2, 0.8)
 
     return dataset
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -202,8 +202,7 @@ def _export(dataset_name, task: TaskType, root_dir):
     dataset.split(0.05)
 
     if task in [TaskType.OBJECT_DETECTION, TaskType.INSTANCE_SEGMENTATION, TaskType.CLASSIFICATION]:
-        export_dir = dataset.export("coco")
-        export_dir = Path(export_dir)
+        export_dir = Path(dataset.export("coco"))
         import_ds = Dataset.from_coco(
             name=f"{task}_import_coco",
             task=task,
@@ -213,8 +212,7 @@ def _export(dataset_name, task: TaskType, root_dir):
         )
         assert len(dataset.get_images()) == len(import_ds.get_images())
     if task in [TaskType.OBJECT_DETECTION, TaskType.INSTANCE_SEGMENTATION, TaskType.CLASSIFICATION]:
-        export_dir = dataset.export("yolo")
-        export_dir = Path(export_dir)
+        export_dir = Path(dataset.export("yolo"))
         import_ds = Dataset.from_yolo(
             name=f"{task}_import_yolo",
             task=task,
@@ -224,8 +222,7 @@ def _export(dataset_name, task: TaskType, root_dir):
         )
         assert len(dataset.get_images()) == len(import_ds.get_images())
     if task in [TaskType.OBJECT_DETECTION, TaskType.CLASSIFICATION]:
-        export_dir = dataset.export("transformers")
-        export_dir = Path(export_dir)
+        export_dir = Path(dataset.export("transformers"))
         import_ds = Dataset.from_transformers(
             name=f"{task}_import_transformers",
             task=task,
@@ -234,8 +231,7 @@ def _export(dataset_name, task: TaskType, root_dir):
         )
         assert len(dataset.get_images()) == len(import_ds.get_images())
     if task in [TaskType.OBJECT_DETECTION, TaskType.TEXT_RECOGNITION, TaskType.CLASSIFICATION]:
-        export_dir = dataset.export("autocare_dlt")
-        export_dir = Path(export_dir)
+        export_dir = Path(dataset.export("autocare_dlt"))
         import_ds = Dataset.from_autocare_dlt(
             name=f"{task}_import_autocare_dlt",
             task=task,
@@ -282,21 +278,6 @@ def test_dummy(tmpdir):
 
     with pytest.raises(ValueError):
         _total_dummy("dummy", TaskType.CLASSIFICATION, 3, 3, 0, tmpdir)
-
-
-# test dummy
-def _dummy(dataset_name, task: TaskType, image_num, category_num, unlabeled_image_num, root_dir):
-    dataset = Dataset.dummy(
-        name=dataset_name,
-        task=task,
-        image_num=image_num,
-        category_num=category_num,
-        unlabeled_image_num=unlabeled_image_num,
-        root_dir=root_dir,
-    )
-    assert len(dataset.get_images()) == image_num
-    assert len(dataset.get_categories()) == category_num
-    assert len(dataset.get_images(labeled=False)) == unlabeled_image_num
 
 
 # test coco

--- a/waffle_hub/dataset/adapter/transformers.py
+++ b/waffle_hub/dataset/adapter/transformers.py
@@ -8,7 +8,6 @@ from waffle_utils.file import io
 from datasets import (
     ClassLabel,
 )
-from datasets import Dataset
 from datasets import Dataset as HFDataset
 from datasets import (
     DatasetDict,
@@ -63,7 +62,7 @@ def _export_transformers_classification(
         if len(image_ids) == 0:
             continue
 
-        dataset[split] = Dataset.from_generator(
+        dataset[split] = HFDataset.from_generator(
             lambda: _export(self.get_images(image_ids)), features=features
         )
 
@@ -140,7 +139,7 @@ def _export_transformers_detection(
         if len(image_ids) == 0:
             continue
 
-        dataset[split] = Dataset.from_generator(
+        dataset[split] = HFDataset.from_generator(
             lambda: _export(self.get_images(image_ids)), features=features
         )
 

--- a/waffle_hub/dataset/adapter/yolo.py
+++ b/waffle_hub/dataset/adapter/yolo.py
@@ -289,8 +289,11 @@ def _import_yolo_classification(self, yolo_root_dir: Path, *args):
             yolo_root_dir / image_path, self.raw_image_dir / file_name, create_directory=True
         )
 
-    for set_type in ["train", "val", "test"]:
-        io.save_json(set2image_ids[set_type], self.set_dir / f"{set_type}.json", True)
+    io.save_json(set2image_ids["train"], self.set_dir / "train.json", True)
+    io.save_json(set2image_ids["val"], self.set_dir / "val.json", True)
+    io.save_json(
+        set2image_ids["test" if "test" in set2image_ids else "val"], self.set_dir / "test.json", True
+    )
 
 
 def _import_yolo_object_detection(self, yolo_root_dir: Path, yaml_path: str):
@@ -310,9 +313,10 @@ def _import_yolo_object_detection(self, yolo_root_dir: Path, yaml_path: str):
                 )
             ]
         )
+
+    path_set_type = {}
     for set_type in ["train", "val", "test"]:
-        if info[set_type] != set_type:
-            raise ValueError(f"yaml file's {set_type} must be {set_type} directory")
+        path_set_type[info[set_type]] = set_type
 
     # image & annotation & set & raw
     new_annotation_id = 1
@@ -324,7 +328,7 @@ def _import_yolo_object_detection(self, yolo_root_dir: Path, yaml_path: str):
         )
     )
     for image_id, image_path in enumerate(image_paths, start=1):
-        set_type = image_path.parts[0]
+        set_type = path_set_type[image_path.parts[0]]
         label_path = image_path.with_suffix(".txt")
         label_parts = list(label_path.parts)
         label_parts[1] = "labels"
@@ -454,6 +458,7 @@ def _import_yolo_instance_segmentation(self, yolo_root_dir: Path, yaml_path: str
 
     for set_type in ["train", "val", "test"]:
         io.save_json(set2image_ids[set_type], self.set_dir / f"{set_type}.json", True)
+
 
 def import_yolo(self, yolo_root_dir: str, yaml_path: str):
     """

--- a/waffle_hub/dataset/adapter/yolo.py
+++ b/waffle_hub/dataset/adapter/yolo.py
@@ -219,7 +219,7 @@ def export_yolo(self, export_dir: Union[str, Path]) -> str:
             "path": str(export_dir.absolute()),
             "train": "train",
             "val": "val",
-            "test": "test",
+            "test": "test" if test_ids else "val",
             "names": {category.category_id - 1: category.name for category in self.get_categories()},
         },
         export_dir / "data.yaml",
@@ -228,17 +228,25 @@ def export_yolo(self, export_dir: Union[str, Path]) -> str:
     return str(export_dir)
 
 
-def _import_yolo_classification(self, yolo_root_dir: Path, *args):
-    # convert to set_type/category/image_path to get set and category information
-    image_paths = list(
-        map(
-            lambda image_path: image_path.relative_to(yolo_root_dir),
-            search.get_image_files(yolo_root_dir),
+# import functions
+def _get_yolo_image_rel_paths(yolo_root_dir: Path, set_paths: list = ["train", "val", "test"]):
+    set_image_rel_path = {}
+    for set_path in set_paths:
+        set_image_rel_path[set_path] = list(
+            map(
+                lambda x: x.relative_to(yolo_root_dir),
+                search.get_image_files(yolo_root_dir / set_path),
+            )
         )
-    )
-    category_group = groupby(image_paths, lambda image_path: image_path.parts[1])
+    return set_image_rel_path
 
-    # category
+
+def _import_yolo_classification(self, yolo_root_dir: Path, *args):
+    # get image relative paths
+    set_image_rel_path = _get_yolo_image_rel_paths(yolo_root_dir, ["train", "val", "test"])
+
+    # get categories
+    category_group = groupby(set_image_rel_path["train"], lambda image_path: image_path.parts[1])
     category_names = {k for k, _ in category_group}
     category_name2id = {}
     for category_id, category_name in enumerate(category_names, start=1):
@@ -252,53 +260,87 @@ def _import_yolo_classification(self, yolo_root_dir: Path, *args):
             ]
         )
 
-    # image & annotation & set & raw
-    new_annotation_id = 1
-    set2image_ids = defaultdict(list)
-    for image_id, image_path in enumerate(image_paths, start=1):
-        set_type = image_path.parts[0]
-        category_name = image_path.parts[1]
-        file_name = "".join(image_path.parts[2:])
+    # convert to waffle format
+    image_id = 1
+    annotation_id = 1
+    for set_name, image_rel_paths in set_image_rel_path.items():
+        set_image_ids = []
+        for image_rel_path in image_rel_paths:
+            image_path = yolo_root_dir / image_rel_path
+            file_name = f"{image_id}{image_path.suffix}"
 
-        set2image_ids[set_type].append(image_id)
+            height, width = cv2.imread(str(image_path)).shape[:2]
+            self.add_images(
+                [
+                    Image.new(
+                        image_id=image_id,
+                        file_name=file_name,
+                        width=width,
+                        height=height,
+                        original_file_name=image_rel_path,
+                    )
+                ]
+            )
+            set_image_ids.append(image_id)
+            io.copy_file(image_path, self.raw_image_dir / file_name, create_directory=True)
 
-        height, width, _ = cv2.imread(str(yolo_root_dir / image_path)).shape
-        self.add_images(
-            [
-                Image.new(
-                    image_id=image_id,
-                    file_name=file_name,
-                    width=width,
-                    height=height,
-                )
-            ]
-        )
+            category_name = image_rel_path.parts[
+                1
+            ]  # image rel path: {set_name}/{category_name}/{file_name}
+            self.add_annotations(
+                [
+                    Annotation.classification(
+                        annotation_id=annotation_id,
+                        image_id=image_id,
+                        category_id=category_name2id[category_name],
+                    )
+                ]
+            )
 
-        self.add_annotations(
-            [
-                Annotation.classification(
-                    annotation_id=new_annotation_id,
-                    image_id=image_id,
-                    category_id=category_name2id[category_name],
-                )
-            ]
-        )
-        new_annotation_id += 1
+            image_id += 1
+            annotation_id += 1
 
-        io.copy_file(
-            yolo_root_dir / image_path, self.raw_image_dir / file_name, create_directory=True
-        )
+        io.save_json(set_image_ids, self.set_dir / f"{set_name}.json", True)
 
-    io.save_json(set2image_ids["train"], self.set_dir / "train.json", True)
-    io.save_json(set2image_ids["val"], self.set_dir / "val.json", True)
-    io.save_json(
-        set2image_ids["test" if "test" in set2image_ids else "val"], self.set_dir / "test.json", True
+    return True
+
+
+def _parse_od_label(line: str, width: int, height: int):
+    """parse label file for od"""
+    category_id, x, y, w, h = map(float, line.split())
+    return {
+        "category_id": int(category_id) + 1,
+        "bbox": [x * width, y * height, w * width, h * height],
+    }
+
+
+def _parse_seg_label(line: str, width: int, height: int):
+    """parse label file for seg"""
+    category_id, *segment = map(float, line.split())
+    segment[::2] = [int(x * width) for x in segment[::2]]
+    segment[1::2] = [y * height for y in segment[1::2]]
+    return {
+        "category_id": int(category_id) + 1,
+        "segmentation": [segment],
+    }
+
+
+def _import_yolo_images_labels(self, yolo_root_dir: Path, yaml_path: str, task: TaskType):
+    """import function for od, seg, keypoint"""
+
+    parse_func = {
+        TaskType.OBJECT_DETECTION: _parse_od_label,
+        TaskType.INSTANCE_SEGMENTATION: _parse_seg_label,
+    }[task]
+
+    info = io.load_yaml(yaml_path)
+
+    # get image relative paths
+    set_image_rel_path = _get_yolo_image_rel_paths(
+        yolo_root_dir, list(set(map(lambda x: info.get(x, None), ["train", "val", "test"])))
     )
 
-
-def _import_yolo_object_detection(self, yolo_root_dir: Path, yaml_path: str):
-    # category
-    info = io.load_yaml(yaml_path)
+    # get categories
     names = info["names"]
     category_name2id = {}
     if isinstance(names, list):
@@ -314,150 +356,57 @@ def _import_yolo_object_detection(self, yolo_root_dir: Path, yaml_path: str):
             ]
         )
 
-    path_set_type = {}
-    for set_type in ["train", "val", "test"]:
-        path_set_type[info[set_type]] = set_type
+    # convert to waffle format
+    image_id = 1
+    annotation_id = 1
+    for set_name, image_rel_paths in set_image_rel_path.items():
+        set_image_ids = []
+        for image_rel_path in image_rel_paths:
+            image_path = (
+                yolo_root_dir / image_rel_path
+            )  # image rel path: {set_name}/images/{file_name(.EXT)}
+            file_name = f"{image_id}{image_path.suffix}"
 
-    # image & annotation & set & raw
-    new_annotation_id = 1
-    set2image_ids = defaultdict(list)
-    image_paths = list(
-        map(
-            lambda image_path: image_path.relative_to(yolo_root_dir),
-            search.get_image_files(yolo_root_dir),
-        )
-    )
-    for image_id, image_path in enumerate(image_paths, start=1):
-        set_type = path_set_type[image_path.parts[0]]
-        label_path = image_path.with_suffix(".txt")
-        label_parts = list(label_path.parts)
-        label_parts[1] = "labels"
-        label_path = yolo_root_dir / Path(*label_parts)
-        file_name = "".join(image_path.parts[2:])
+            height, width = cv2.imread(str(image_path)).shape[:2]
+            self.add_images(
+                [
+                    Image.new(
+                        image_id=image_id,
+                        file_name=file_name,
+                        width=width,
+                        height=height,
+                        original_file_name=image_rel_path,
+                    )
+                ]
+            )
+            set_image_ids.append(image_id)
+            io.copy_file(image_path, self.raw_image_dir / file_name, create_directory=True)
 
-        set2image_ids[set_type].append(image_id)
+            label_path = image_rel_path.with_suffix(
+                ".txt"
+            )  # label rel path: {set_name}/labels/{file_name(.txt)}
+            label_parts = list(label_path.parts)
+            label_parts[1] = "labels"
+            label_path = yolo_root_dir / Path(*label_parts)
+            with label_path.open("r") as f:
+                lines = f.readlines()
 
-        height, width, _ = cv2.imread(str(yolo_root_dir / image_path)).shape
-        self.add_images(
-            [
-                Image.new(
-                    image_id=image_id,
-                    file_name=file_name,
-                    width=width,
-                    height=height,
-                )
-            ]
-        )
-
-        # ann
-        with label_path.open("r") as f:
-            for line in f.readlines():
-                category_id, x, y, w, h = map(float, line.split())
-                x, y, w, h = x * width, y * height, w * width, h * height
+            for line in lines:
+                annotation = parse_func(line, width, height)
                 self.add_annotations(
                     [
-                        Annotation.object_detection(
-                            annotation_id=new_annotation_id,
+                        Annotation.new(
+                            annotation_id=annotation_id,
                             image_id=image_id,
-                            category_id=int(category_id) + 1,
-                            bbox=[x, y, x + w, y + h],
+                            task=task,
+                            **annotation,
                         )
                     ]
                 )
-                new_annotation_id += 1
+                annotation_id += 1
+            image_id += 1
 
-        io.copy_file(
-            yolo_root_dir / image_path, self.raw_image_dir / file_name, create_directory=True
-        )
-
-    for set_type in ["train", "val", "test"]:
-        io.save_json(set2image_ids[set_type], self.set_dir / f"{set_type}.json", True)
-
-
-def _import_yolo_instance_segmentation(self, yolo_root_dir: Path, yaml_path: str):
-    # category
-    info = io.load_yaml(yaml_path)
-    names = info["names"]
-    category_name2id = {}
-    if isinstance(names, list):
-        names = {category_id: category_name for category_id, category_name in enumerate(names)}
-    for category_id, category_name in names.items():
-        category_name2id[category_name] = category_id + 1
-        self.add_categories(
-            [
-                Category.instance_segmentation(
-                    category_id=category_id + 1,
-                    name=category_name,
-                )
-            ]
-        )
-    for set_type in ["train", "val", "test"]:
-        if info[set_type] != set_type:
-            raise ValueError(f"yaml file's {set_type} must be {set_type} directory")
-
-    # image & annotation & set & raw
-    new_annotation_id = 1
-    set2image_ids = defaultdict(list)
-    image_paths = list(
-        map(
-            lambda image_path: image_path.relative_to(yolo_root_dir),
-            search.get_image_files(yolo_root_dir),
-        )
-    )
-    for image_id, image_path in enumerate(image_paths, start=1):
-        set_type = image_path.parts[0]
-        label_path = image_path.with_suffix(".txt")
-        label_parts = list(label_path.parts)
-        label_parts[1] = "labels"
-        label_path = yolo_root_dir / Path(*label_parts)
-        file_name = "".join(image_path.parts[2:])
-
-        set2image_ids[set_type].append(image_id)
-
-        height, width, _ = cv2.imread(str(yolo_root_dir / image_path)).shape
-        self.add_images(
-            [
-                Image.new(
-                    image_id=image_id,
-                    file_name=file_name,
-                    width=width,
-                    height=height,
-                )
-            ]
-        )
-
-        # ann
-        with label_path.open("r") as f:
-            for line in f.readlines():
-                label = list(map(float, line.split()))
-                category_id = int(label[0])
-                segment = label[1:]
-                segment[::2] = [int(x * width) for x in segment[::2]]
-                segment[1::2] = [y * height for y in segment[1::2]]
-                x1 = min(segment[::2])
-                y1 = min(segment[1::2])
-                x2 = max(segment[::2])
-                y2 = max(segment[1::2])
-
-                self.add_annotations(
-                    [
-                        Annotation.instance_segmentation(
-                            annotation_id=new_annotation_id,
-                            image_id=image_id,
-                            category_id=int(category_id) + 1,
-                            segmentation=[segment],
-                            bbox=[x1, y1, x2, y2],
-                        )
-                    ]
-                )
-                new_annotation_id += 1
-
-        io.copy_file(
-            yolo_root_dir / image_path, self.raw_image_dir / file_name, create_directory=True
-        )
-
-    for set_type in ["train", "val", "test"]:
-        io.save_json(set2image_ids[set_type], self.set_dir / f"{set_type}.json", True)
+        io.save_json(set_image_ids, self.set_dir / f"{set_name}.json", True)
 
 
 def import_yolo(self, yolo_root_dir: str, yaml_path: str):
@@ -468,18 +417,15 @@ def import_yolo(self, yolo_root_dir: str, yaml_path: str):
         yaml_path (str): Path to the yaml file.
     """
     if self.task == TaskType.OBJECT_DETECTION:
-        _import = _import_yolo_object_detection
+        _import = _import_yolo_images_labels
     elif self.task == TaskType.CLASSIFICATION:
         _import = _import_yolo_classification
     elif self.task == TaskType.INSTANCE_SEGMENTATION:
-        _import = _import_yolo_instance_segmentation
+        _import = _import_yolo_images_labels
     else:
         raise ValueError(f"Unsupported task: {self.task}")
 
-    if isinstance(yolo_root_dir, str):
-        yolo_root_dir = Path(yolo_root_dir)
-
-    _import(self, yolo_root_dir, yaml_path)
+    _import(self, Path(yolo_root_dir), yaml_path, self.task)
 
     # TODO: add unlabeled set
     io.save_json([], self.unlabeled_set_file, create_directory=True)

--- a/waffle_hub/dataset/adapter/yolo.py
+++ b/waffle_hub/dataset/adapter/yolo.py
@@ -349,9 +349,10 @@ def _import_yolo_images_labels(self, yolo_root_dir: Path, yaml_path: str, task: 
         category_name2id[category_name] = category_id + 1
         self.add_categories(
             [
-                Category.object_detection(
+                Category.new(
                     category_id=category_id + 1,
                     name=category_name,
+                    task=task,
                 )
             ]
         )

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -731,29 +731,34 @@ class Dataset:
         """
         ds = Dataset.new(name=name, task=task, root_dir=root_dir)
 
-        if isinstance(coco_file, list) and isinstance(coco_root_dir, list):
-            if len(coco_file) != len(coco_root_dir):
-                raise ValueError("coco_file and coco_root_dir should have same length.")
-        if not isinstance(coco_file, list) and isinstance(coco_root_dir, list):
-            raise ValueError(
-                "ambiguous input. The number of coco_file should be same or greater than coco_root_dir."
-            )
-        if not isinstance(coco_file, list):
-            coco_file = [coco_file]
-        if not isinstance(coco_root_dir, list):
-            coco_root_dir = [coco_root_dir] * len(coco_file)
+        try:
+            if isinstance(coco_file, list) and isinstance(coco_root_dir, list):
+                if len(coco_file) != len(coco_root_dir):
+                    raise ValueError("coco_file and coco_root_dir should have same length.")
+            if not isinstance(coco_file, list) and isinstance(coco_root_dir, list):
+                raise ValueError(
+                    "ambiguous input. The number of coco_file should be same or greater than coco_root_dir."
+                )
+            if not isinstance(coco_file, list):
+                coco_file = [coco_file]
+            if not isinstance(coco_root_dir, list):
+                coco_root_dir = [coco_root_dir] * len(coco_file)
 
-        coco_files = coco_file
-        coco_root_dirs = coco_root_dir
+            coco_files = coco_file
+            coco_root_dirs = coco_root_dir
 
-        import_coco(ds, coco_files, coco_root_dirs)
+            import_coco(ds, coco_files, coco_root_dirs)
 
-        if len(coco_files) == 2:
-            logger.info("copying val set to test set")
-            io.copy_file(ds.val_set_file, ds.test_set_file, create_directory=True)
+            if len(coco_files) == 2:
+                logger.info("copying val set to test set")
+                io.copy_file(ds.val_set_file, ds.test_set_file, create_directory=True)
 
-        # TODO: add unlabeled set
-        io.save_json([], ds.unlabeled_set_file, create_directory=True)
+            # TODO: add unlabeled set
+            io.save_json([], ds.unlabeled_set_file, create_directory=True)
+
+        except Exception as e:
+            ds.delete()
+            raise e
 
         return ds
 
@@ -797,29 +802,34 @@ class Dataset:
         """
         ds = Dataset.new(name=name, task=task, root_dir=root_dir)
 
-        if isinstance(coco_file, list) and isinstance(coco_root_dir, list):
-            if len(coco_file) != len(coco_root_dir):
-                raise ValueError("coco_file and coco_root_dir should have same length.")
-        if not isinstance(coco_file, list) and isinstance(coco_root_dir, list):
-            raise ValueError(
-                "ambiguous input. The number of coco_file should be same or greater than coco_root_dir."
-            )
-        if not isinstance(coco_file, list):
-            coco_file = [coco_file]
-        if not isinstance(coco_root_dir, list):
-            coco_root_dir = [coco_root_dir] * len(coco_file)
+        try:
+            if isinstance(coco_file, list) and isinstance(coco_root_dir, list):
+                if len(coco_file) != len(coco_root_dir):
+                    raise ValueError("coco_file and coco_root_dir should have same length.")
+            if not isinstance(coco_file, list) and isinstance(coco_root_dir, list):
+                raise ValueError(
+                    "ambiguous input. The number of coco_file should be same or greater than coco_root_dir."
+                )
+            if not isinstance(coco_file, list):
+                coco_file = [coco_file]
+            if not isinstance(coco_root_dir, list):
+                coco_root_dir = [coco_root_dir] * len(coco_file)
 
-        coco_files = coco_file
-        coco_root_dirs = coco_root_dir
+            coco_files = coco_file
+            coco_root_dirs = coco_root_dir
 
-        import_autocare_dlt(ds, coco_files, coco_root_dirs)
+            import_autocare_dlt(ds, coco_files, coco_root_dirs)
 
-        if len(coco_files) == 2:
-            logging.info("copying val set to test set")
-            io.copy_file(ds.val_set_file, ds.test_set_file, create_directory=True)
+            if len(coco_files) == 2:
+                logging.info("copying val set to test set")
+                io.copy_file(ds.val_set_file, ds.test_set_file, create_directory=True)
 
-        # TODO: add unlabeled set
-        io.save_json([], ds.unlabeled_set_file, create_directory=True)
+            # TODO: add unlabeled set
+            io.save_json([], ds.unlabeled_set_file, create_directory=True)
+
+        except Exception as e:
+            ds.delete()
+            raise e
 
         return ds
 
@@ -852,7 +862,12 @@ class Dataset:
 
         ds = Dataset(name=name, task=task, root_dir=root_dir)
 
-        import_yolo(ds, yolo_root_dir, yaml_path)
+        try:
+            import_yolo(ds, yolo_root_dir, yaml_path)
+
+        except Exception as e:
+            ds.delete()
+            raise e
 
         return ds
 
@@ -886,10 +901,15 @@ class Dataset:
         """
         ds = Dataset.new(name=name, task=task, root_dir=root_dir)
 
-        import_transformers(ds, dataset_dir)
+        try:
+            import_transformers(ds, dataset_dir)
 
-        # TODO: add unlabeled set
-        io.save_json([], ds.unlabeled_set_file, create_directory=True)
+            # TODO: add unlabeled set
+            io.save_json([], ds.unlabeled_set_file, create_directory=True)
+
+        except Exception as e:
+            ds.delete()
+            raise e
 
         return ds
 

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -1268,7 +1268,6 @@ class Dataset:
                 if test_ratio == 0.0:
                     train_ids.extend(image_ids[:train_num])
                     val_ids.extend(image_ids[train_num:])
-                    test_ids = val_ids
                 else:
                     train_ids.extend(image_ids[:train_num])
                     val_ids.extend(image_ids[train_num : train_num + val_num])

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -860,7 +860,7 @@ class Dataset:
             Dataset: Imported dataset.
         """
 
-        ds = Dataset(name=name, task=task, root_dir=root_dir)
+        ds = Dataset.new(name=name, task=task, root_dir=root_dir)
 
         try:
             import_yolo(ds, yolo_root_dir, yaml_path)
@@ -1315,10 +1315,14 @@ class Dataset:
         if not self.train_set_file.exists():
             raise FileNotFoundError("There is no set files. Please run ds.split() first")
 
-        train_ids: list[int] = io.load_json(self.train_set_file)
-        val_ids: list[int] = io.load_json(self.val_set_file)
-        test_ids: list[int] = io.load_json(self.test_set_file)
-        unlabeled_ids: list[int] = io.load_json(self.unlabeled_set_file)
+        train_ids: list[int] = (
+            io.load_json(self.train_set_file) if self.train_set_file.exists() else []
+        )
+        val_ids: list[int] = io.load_json(self.val_set_file) if self.val_set_file.exists() else []
+        test_ids: list[int] = io.load_json(self.test_set_file) if self.test_set_file.exists() else []
+        unlabeled_ids: list[int] = (
+            io.load_json(self.unlabeled_set_file) if self.unlabeled_set_file.exists() else []
+        )
 
         return [train_ids, val_ids, test_ids, unlabeled_ids]
 

--- a/waffle_hub/hub/adapter/autocare_dlt/autocare_dlt_hub.py
+++ b/waffle_hub/hub/adapter/autocare_dlt/autocare_dlt_hub.py
@@ -195,16 +195,19 @@ class AutocareDLTHub(Hub):
     def on_train_start(self, cfg: TrainConfig):
         # set data
         cfg.dataset_path: Path = Path(cfg.dataset_path)
+        train_coco_file = cfg.dataset_path / "train.json"
+        val_coco_file = cfg.dataset_path / "val.json"
+        test_coco_file = cfg.dataset_path / "test.json"
         data_config = get_data_config(
             self.DATA_TYPE_MAP[self.task],
             cfg.image_size if isinstance(cfg.image_size, list) else [cfg.image_size, cfg.image_size],
             cfg.batch_size,
             cfg.workers,
-            str(cfg.dataset_path / "train.json"),
+            str(train_coco_file),
             str(cfg.dataset_path / "images"),
-            str(cfg.dataset_path / "val.json"),
+            str(val_coco_file),
             str(cfg.dataset_path / "images"),
-            str(cfg.dataset_path / "test.json"),
+            str(test_coco_file) if test_coco_file.exists() else str(val_coco_file),
             str(cfg.dataset_path / "images"),
         )
         if self.model_type == "LicencePlateRecognition":

--- a/waffle_hub/schema/fields/annotation.py
+++ b/waffle_hub/schema/fields/annotation.py
@@ -244,7 +244,7 @@ class Annotation(BaseField):
         Returns:
             Annotation: annotation class
         """
-        return cls(
+        return (getattr(cls, task.lower()) if task else cls)(
             annotation_id=annotation_id,
             image_id=image_id,
             category_id=category_id,

--- a/waffle_hub/schema/fields/category.py
+++ b/waffle_hub/schema/fields/category.py
@@ -111,7 +111,7 @@ class Category(BaseField):
         Returns:
             Category: category class
         """
-        return cls(
+        return (getattr(cls, task.lower()) if task else cls)(
             category_id=category_id,
             name=name,
             supercategory=supercategory,

--- a/waffle_hub/schema/fields/image.py
+++ b/waffle_hub/schema/fields/image.py
@@ -13,6 +13,7 @@ class Image(BaseField):
         width: int,
         height: int,
         # optional
+        original_file_name: str = None,
         date_captured: str = None,
     ):
 
@@ -20,6 +21,7 @@ class Image(BaseField):
         self.file_name = file_name
         self.width = width
         self.height = height
+        self.original_file_name = original_file_name
         self.date_captured = date_captured
 
     # properties
@@ -39,7 +41,7 @@ class Image(BaseField):
         return self.__file_name
 
     @file_name.setter
-    @type_validator(str)
+    @type_validator(str, strict=False)
     def file_name(self, v):
         self.__file_name = v
 
@@ -62,6 +64,15 @@ class Image(BaseField):
         self.__height = v
 
     @property
+    def original_file_name(self):
+        return self.__original_file_name
+
+    @original_file_name.setter
+    @type_validator(str, strict=False)
+    def original_file_name(self, v):
+        self.__original_file_name = v or self.file_name
+
+    @property
     def date_captured(self):
         return self.__date_captured
 
@@ -80,6 +91,7 @@ class Image(BaseField):
         file_name: str,
         width: int,
         height: int,
+        original_file_name: str = None,
         date_captured: str = None,
         **kwargs,
     ) -> "Image":
@@ -90,6 +102,7 @@ class Image(BaseField):
             file_name (str): file name. relative file path.
             width (int): image width.
             height (int): image height.
+            original_file_name (str): original file name. relative file path.
             date_captured (str): date_captured string. "%Y-%m-%d %H:%M:%S"
 
         Returns:
@@ -109,6 +122,7 @@ class Image(BaseField):
             "file_name": self.file_name,
             "width": self.width,
             "height": self.height,
+            "original_file_name": self.original_file_name,
             "date_captured": self.date_captured,
         }
 


### PR DESCRIPTION
- do not export test set if test_ratio was set to 0.
  - This change brings some changes to each `Hub` adapters.
- yolo dataset format is special case that they can have same image name. because, its splits are done by splitting the directory. so, it is impossible to maintain their original image name after splitting in waffle.
  - not to lost the original image name, `original_file_name` field has been added to `Image`.
- yolo adapter refactoring