### PR TITLE
Hotfix: Pillow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,3 @@ py-cpuinfo>=8.0.0
 shapely>=2.0.0
 fire==0.5.0
 Pillow<=9.5.0
-
-# webserver
-fastapi
-uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,8 @@ pycocotools>=2.0.2
 py-cpuinfo>=8.0.0
 shapely>=2.0.0
 fire==0.5.0
+Pillow<=9.5.0
+
+# webserver
+fastapi
+uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ pycocotools>=2.0.2
 py-cpuinfo>=8.0.0
 shapely>=2.0.0
 fire==0.5.0
-Pillow<=9.5.0
+Pillow==9.5.0


### PR DESCRIPTION
Pillow version `10.0.0` was released as of July 1, but version dependency requires `Pillow<=9.5.0`