### PR TITLE
Update `from_yolo` function

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,3 @@ py-cpuinfo>=8.0.0
 shapely>=2.0.0
 fire==0.5.0
 Pillow<=9.5.0
-
-# webserver
-fastapi
-uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,8 @@ pycocotools>=2.0.2
 py-cpuinfo>=8.0.0
 shapely>=2.0.0
 fire==0.5.0
+Pillow<=9.5.0
+
+# webserver
+fastapi
+uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ pycocotools>=2.0.2
 py-cpuinfo>=8.0.0
 shapely>=2.0.0
 fire==0.5.0
-Pillow<=9.5.0
+Pillow==9.5.0

--- a/waffle_hub/dataset/adapter/yolo.py
+++ b/waffle_hub/dataset/adapter/yolo.py
@@ -339,7 +339,8 @@ def _import_yolo_images_labels(self, yolo_root_dir: Path, yaml_path: str, task: 
 
     # get image relative paths
     set_image_rel_path = _get_yolo_image_rel_paths(
-        yolo_root_dir, list(set(map(lambda x: info.get(x, None), ["train", "val", "test"])))
+        yolo_root_dir,
+        list(set(map(lambda x: info.get(x, None), [info["train"], info["val"], info["test"]]))),
     )
 
     # get categories

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -935,7 +935,8 @@ class Dataset:
             root_dir (str, optional): Dataset root directory. Defaults to None.
 
         Example:
-            >>> ds = Dataset.from_yolo("yolo", "classification", "path/to/yolo.yaml")
+            >>> ds = Dataset.from_yolo("yolo", "classification", "path/to/yolo_root_dir")
+            >>> ds = Dataset.from_yolo("yolo", "object_detection", "path/to/yolo_root_dir", "path/to/yolo.yaml")
 
         Returns:
             Dataset: Imported dataset.


### PR DESCRIPTION
In object_detection and segmentation, the `from_yolo` function now utilizes the path specified in the YAML config file.

However, since the classification has not been modified, only accepts fixed paths for 'train', 'val' and 'test'.
The reason why the modification was not made is that Ultralytics uses a fixed path.
I will write an issue in Ultralytics later, and if it is modified, I will also revise the waffle then.

resolved #260 