### PR TITLE
Update `from_yolo` function

### DIFF
--- a/waffle_hub/dataset/adapter/yolo.py
+++ b/waffle_hub/dataset/adapter/yolo.py
@@ -343,9 +343,7 @@ def _import_yolo_images_labels(self, yolo_root_dir: Path, yaml_path: str, task: 
             set(
                 map(
                     lambda x: info.get(x, None),
-                    [info["train"], info["val"], info["test"]]
-                    if "test" in info.keys()
-                    else [info["train"], info["val"], info["val"]],
+                    [info["train"], info["val"], info.get("test", info["val"])],
                 )
             )
         ),

--- a/waffle_hub/dataset/adapter/yolo.py
+++ b/waffle_hub/dataset/adapter/yolo.py
@@ -336,11 +336,19 @@ def _import_yolo_images_labels(self, yolo_root_dir: Path, yaml_path: str, task: 
     }[task]
 
     info = io.load_yaml(yaml_path)
-
     # get image relative paths
     set_image_rel_path = _get_yolo_image_rel_paths(
         yolo_root_dir,
-        list(set(map(lambda x: info.get(x, None), [info["train"], info["val"], info["test"]]))),
+        list(
+            set(
+                map(
+                    lambda x: info.get(x, None),
+                    [info["train"], info["val"], info["test"]]
+                    if "test" in info.keys()
+                    else [info["train"], info["val"], info["val"]],
+                )
+            )
+        ),
     )
 
     # get categories

--- a/waffle_hub/dataset/adapter/yolo.py
+++ b/waffle_hub/dataset/adapter/yolo.py
@@ -339,7 +339,8 @@ def _import_yolo_images_labels(self, yolo_root_dir: Path, yaml_path: str, task: 
 
     # get image relative paths
     set_image_rel_path = _get_yolo_image_rel_paths(
-        yolo_root_dir, list(set(map(lambda x: info.get(x, None), ["train", "val", "test"])))
+        yolo_root_dir,
+        list(set(map(lambda x: info.get(x, None), [info["train"], info["val"], info["test"]]))),
     )
 
     # get categories

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -935,7 +935,8 @@ class Dataset:
             root_dir (str, optional): Dataset root directory. Defaults to None.
 
         Example:
-            >>> ds = Dataset.from_yolo("yolo", "classification", "path/to/yolo.yaml")
+            >>> ds = Dataset.from_yolo("yolo", "classification", "path/to/yolo_root_dir")
+            >>> ds = Dataset.from_yolo("yolo", "object_detection", "path/to/yolo_root_dir", "path/to/yolo.yaml")
 
         Returns:
             Dataset: Imported dataset.


### PR DESCRIPTION
In OBJECT_DETECTION and SEGMENTATION, the `from_yolo` function now utilizes the path specified in the YAML config file.

However, since the CLASSIFICATION has not been modified, only accepts fixed paths for 'train', 'val' and 'test'.
The reason why the modification was not made is that Ultralytics uses a fixed path.
I will write an issue in Ultralytics later, and if it is modified, I will also revise the waffle then.

resolved #260