### PR TITLE
HotFix: inference error (single image path)

### DIFF
--- a/waffle_hub/hub/hub.py
+++ b/waffle_hub/hub/hub.py
@@ -1491,7 +1491,7 @@ class Hub:
                     source = source.absolute()
                     source_type = "image"
                 elif source.suffix in IMAGE_EXTS:
-                    source = [source.absolute()]
+                    source = source.absolute()
                     source_type = "image"
                 elif source.suffix in VIDEO_EXTS:
                     source = str(source.absolute())

--- a/waffle_hub/utils/data.py
+++ b/waffle_hub/utils/data.py
@@ -109,7 +109,7 @@ def resize_image(
 
 def get_image_transform(image_size: Union[int, list[int]], letter_box: bool = False):
     def transform(image: Union[np.ndarray, str]) -> tuple[torch.Tensor, ImageInfo]:
-        if isinstance(image, str):
+        if isinstance(image, (str, Path)):
             image = load_image(image)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         image, image_info = resize_image(image, image_size, letter_box)


### PR DESCRIPTION
- Fixed
  - Error when 'inference' input is a single image path