### PR TITLE
Modify: status naming & Hotfix: `check_train_sanity`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ def _train(hub_name: str, dataset: Dataset, tmpdir: Path):
     ret = run_cli(cmd)
     assert ret.returncode == 0
     assert (tmpdir / hub_name / "artifacts").exists()
-    assert (tmpdir / hub_name / "working_infos" / "training_info.json").exists()
+    assert (tmpdir / hub_name / "running_status" / "training_status.json").exists()
 
 
 def _delete_artifact(hub_name: str, tmpdir: Path):
@@ -74,7 +74,7 @@ def _train_advance_params(hub_name: str, dataset: Dataset, tmpdir: Path):
     ret = run_cli(cmd)
     assert ret.returncode == 0
     assert (tmpdir / hub_name / "artifacts").exists()
-    assert (tmpdir / hub_name / "working_infos" / "training_info.json").exists()
+    assert (tmpdir / hub_name / "running_status" / "training_status.json").exists()
 
 
 def _inference(hub_name: str, dataset: Dataset, tmpdir: Path):
@@ -89,7 +89,7 @@ def _inference(hub_name: str, dataset: Dataset, tmpdir: Path):
     ret = run_cli(cmd)
     assert ret.returncode == 0
     assert (tmpdir / hub_name / "inferences").exists()
-    assert (tmpdir / hub_name / "working_infos" / "inferencing_info.json").exists()
+    assert (tmpdir / hub_name / "running_status" / "inferencing_status.json").exists()
 
 
 def _evaluate(hub_name: str, dataset: Dataset, tmpdir: Path):
@@ -105,7 +105,7 @@ def _evaluate(hub_name: str, dataset: Dataset, tmpdir: Path):
     ret = run_cli(cmd)
     assert ret.returncode == 0
     assert (tmpdir / hub_name / "evaluate.json").exists()
-    assert (tmpdir / hub_name / "working_infos" / "evaluating_info.json").exists()
+    assert (tmpdir / hub_name / "running_status" / "evaluating_status.json").exists()
 
 
 def _export_onnx(hub_name: str, tmpdir: Path):
@@ -117,7 +117,7 @@ def _export_onnx(hub_name: str, tmpdir: Path):
     ret = run_cli(cmd)
     assert ret.returncode == 0
     assert (tmpdir / hub_name / "weights" / "model.onnx").exists()
-    assert (tmpdir / hub_name / "working_infos" / "exporting_onnx_info.json").exists()
+    assert (tmpdir / hub_name / "running_status" / "exporting_onnx_status.json").exists()
 
 
 def _export_waffle(hub_name: str, tmpdir: Path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,6 +128,7 @@ def _export_waffle(hub_name: str, tmpdir: Path):
     ret = run_cli(cmd)
     assert ret.returncode == 0
     assert (tmpdir / hub_name / f"{hub_name}.waffle").exists()
+    assert (tmpdir / hub_name / "running_status" / "exporting_waffle_status.json").exists()
 
 
 def _from_waffle_file(hub_name: str, dataset: Dataset, tmpdir: Path):

--- a/tests/test_ddp.py
+++ b/tests/test_ddp.py
@@ -1,7 +1,7 @@
 import time
 from pathlib import Path
 
-from waffle_hub import TaskType, TrainStatus
+from waffle_hub import TaskType, TrainStatusDesc
 from waffle_hub.dataset import Dataset
 from waffle_hub.hub import Hub
 from waffle_hub.schema.result import TrainResult
@@ -19,7 +19,7 @@ def _train(hub, dataset: Dataset, image_size: int):
     )
 
     training_status = hub.get_training_status()
-    assert training_status.status_desc == TrainStatus.SUCCESS
+    assert training_status.status_desc == TrainStatusDesc.SUCCESS
     assert training_status.step == training_status.total_step
 
     assert len(result.metrics) >= 1

--- a/tests/test_ddp.py
+++ b/tests/test_ddp.py
@@ -18,9 +18,9 @@ def _train(hub, dataset: Dataset, image_size: int):
         workers=0,
     )
 
-    training_info = hub.get_training_info()
-    assert training_info.status == TrainStatus.SUCCESS
-    assert training_info.step == training_info.total_step
+    training_status = hub.get_training_status()
+    assert training_status.status_desc == TrainStatus.SUCCESS
+    assert training_status.step == training_status.total_step
 
     assert len(result.metrics) >= 1
     assert Path(result.best_ckpt_file).exists()

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -7,11 +7,12 @@ import pytest
 import torch
 
 from waffle_hub import (
-    EvaluateStatus,
-    ExportStatus,
-    InferenceStatus,
+    EvaluateStatusDesc,
+    ExportOnnxStatusDesc,
+    ExportWaffleStatusDesc,
+    InferenceStatusDesc,
     TaskType,
-    TrainStatus,
+    TrainStatusDesc,
 )
 from waffle_hub.dataset import Dataset
 from waffle_hub.hub import Hub
@@ -38,7 +39,7 @@ def _train(hub, dataset: Dataset, image_size: int, advance_params: dict = None):
     )
 
     training_status = hub.get_training_status()
-    assert training_status.status_desc == TrainStatus.SUCCESS
+    assert training_status.status_desc == TrainStatusDesc.SUCCESS
     assert training_status.step == training_status.total_step
     assert len(result.metrics) >= 1
     assert len(result.eval_metrics) >= 1
@@ -63,7 +64,7 @@ def _evaluate(hub, dataset: Dataset):
     )
 
     evaluating_status = hub.get_evaluating_status()
-    assert evaluating_status.status_desc == EvaluateStatus.SUCCESS
+    assert evaluating_status.status_desc == EvaluateStatusDesc.SUCCESS
     assert evaluating_status.step == evaluating_status.total_step
     assert len(result.eval_metrics) >= 1
 
@@ -80,7 +81,7 @@ def _inference(hub, source: str):
     )
 
     inferencing_status = hub.get_inferencing_status()
-    assert inferencing_status.status_desc == InferenceStatus.SUCCESS
+    assert inferencing_status.status_desc == InferenceStatusDesc.SUCCESS
     assert inferencing_status.step == inferencing_status.total_step
     assert len(result.predictions) >= 1
     assert Path(result.draw_dir).exists()
@@ -95,7 +96,7 @@ def _export_onnx(hub, half: bool = False):
     )
 
     exporting_onnx_status = hub.get_exporting_onnx_status()
-    assert exporting_onnx_status.status_desc == ExportStatus.SUCCESS
+    assert exporting_onnx_status.status_desc == ExportOnnxStatusDesc.SUCCESS
     assert Path(result.onnx_file).exists()
 
     return result
@@ -104,6 +105,8 @@ def _export_onnx(hub, half: bool = False):
 def _export_waffle(hub):
     result: ExportWaffleResult = hub.export_waffle()
 
+    exporting_waffle_status = hub.get_exporting_waffle_status()
+    assert exporting_waffle_status.status_desc == ExportWaffleStatusDesc.SUCCESS
     assert Path(result.waffle_file).exists()
 
     return result
@@ -264,7 +267,7 @@ def test_ultralytics_object_detection_advance_params(
 
     with pytest.raises(ValueError):
         _total(hub, dataset, image_size, tmpdir, {"box": 4, "dummy_adv_param": 2})
-        assert hub.get_training_status().status_desc == TrainStatus.FAILED
+        assert hub.get_training_status().status_desc == TrainStatusDesc.FAILED
         import_hub = Hub.load(name=import_hub_name, root_dir=tmpdir)
         import_hub.delete_hub()
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -37,9 +37,9 @@ def _train(hub, dataset: Dataset, image_size: int, advance_params: dict = None):
         advance_params=advance_params,
     )
 
-    training_info = hub.get_training_info()
-    assert training_info.status == TrainStatus.SUCCESS
-    assert training_info.step == training_info.total_step
+    training_status = hub.get_training_status()
+    assert training_status.status_desc == TrainStatus.SUCCESS
+    assert training_status.step == training_status.total_step
     assert len(result.metrics) >= 1
     assert len(result.eval_metrics) >= 1
     assert Path(result.best_ckpt_file).exists()
@@ -62,9 +62,9 @@ def _evaluate(hub, dataset: Dataset):
         workers=0,
     )
 
-    evaluating_info = hub.get_evaluating_info()
-    assert evaluating_info.status == EvaluateStatus.SUCCESS
-    assert evaluating_info.step == evaluating_info.total_step
+    evaluating_status = hub.get_evaluating_status()
+    assert evaluating_status.status_desc == EvaluateStatus.SUCCESS
+    assert evaluating_status.step == evaluating_status.total_step
     assert len(result.eval_metrics) >= 1
 
     return result
@@ -79,9 +79,9 @@ def _inference(hub, source: str):
         workers=0,
     )
 
-    inferencing_info = hub.get_inferencing_info()
-    assert inferencing_info.status == InferenceStatus.SUCCESS
-    assert inferencing_info.step == inferencing_info.total_step
+    inferencing_status = hub.get_inferencing_status()
+    assert inferencing_status.status_desc == InferenceStatus.SUCCESS
+    assert inferencing_status.step == inferencing_status.total_step
     assert len(result.predictions) >= 1
     assert Path(result.draw_dir).exists()
 
@@ -94,8 +94,8 @@ def _export_onnx(hub, half: bool = False):
         device="cpu",
     )
 
-    exporting_onnx_info = hub.get_exporting_onnx_info()
-    assert exporting_onnx_info.status == ExportStatus.SUCCESS
+    exporting_onnx_status = hub.get_exporting_onnx_status()
+    assert exporting_onnx_status.status_desc == ExportStatus.SUCCESS
     assert Path(result.onnx_file).exists()
 
     return result
@@ -264,7 +264,7 @@ def test_ultralytics_object_detection_advance_params(
 
     with pytest.raises(ValueError):
         _total(hub, dataset, image_size, tmpdir, {"box": 4, "dummy_adv_param": 2})
-        assert hub.get_training_info().status == TrainStatus.FAILED
+        assert hub.get_training_status().status_desc == TrainStatus.FAILED
         import_hub = Hub.load(name=import_hub_name, root_dir=tmpdir)
         import_hub.delete_hub()
 

--- a/waffle_hub/__init__.py
+++ b/waffle_hub/__init__.py
@@ -81,8 +81,8 @@ class SplitMethod(BaseEnum):
     STRATIFIED = enum.auto()
 
 
-# for changeable status
-class TrainStatus(BaseEnum):
+# for changeable status desc
+class TrainStatusDesc(BaseEnum):
     INIT = enum.auto()
     RUNNING = enum.auto()
     SUCCESS = enum.auto()
@@ -90,7 +90,7 @@ class TrainStatus(BaseEnum):
     STOPPED = enum.auto()
 
 
-class EvaluateStatus(BaseEnum):
+class EvaluateStatusDesc(BaseEnum):
     INIT = enum.auto()
     RUNNING = enum.auto()
     SUCCESS = enum.auto()
@@ -98,7 +98,7 @@ class EvaluateStatus(BaseEnum):
     STOPPED = enum.auto()
 
 
-class InferenceStatus(BaseEnum):
+class InferenceStatusDesc(BaseEnum):
     INIT = enum.auto()
     RUNNING = enum.auto()
     SUCCESS = enum.auto()
@@ -106,7 +106,15 @@ class InferenceStatus(BaseEnum):
     STOPPED = enum.auto()
 
 
-class ExportStatus(BaseEnum):
+class ExportOnnxStatusDesc(BaseEnum):
+    INIT = enum.auto()
+    RUNNING = enum.auto()
+    SUCCESS = enum.auto()
+    FAILED = enum.auto()
+    STOPPED = enum.auto()
+
+
+class ExportWaffleStatusDesc(BaseEnum):
     INIT = enum.auto()
     RUNNING = enum.auto()
     SUCCESS = enum.auto()

--- a/waffle_hub/hub/adapter/autocare_dlt/autocare_dlt_hub.py
+++ b/waffle_hub/hub/adapter/autocare_dlt/autocare_dlt_hub.py
@@ -25,7 +25,7 @@ from waffle_hub.hub.adapter.autocare_dlt.configs import (
 )
 from waffle_hub.hub.model.wrapper import ModelWrapper
 from waffle_hub.schema.configs import TrainConfig
-from waffle_hub.utils.working_info_logger import TrainingInfoLogger
+from waffle_hub.utils.running_status_logger import TrainingStatusLogger
 
 from .config import DATA_TYPE_MAP, DEFAULT_PARAMS, MODEL_TYPES, WEIGHT_PATH
 
@@ -272,7 +272,7 @@ class AutocareDLTHub(Hub):
 
         cfg.dataset_path = str(cfg.dataset_path.absolute())
 
-    def training(self, cfg: TrainConfig, info_logger: TrainingInfoLogger):
+    def training(self, cfg: TrainConfig, status_logger: TrainingStatusLogger):
         results = train.run(
             exp_name="train",
             model_cfg=str(cfg.model_config),

--- a/waffle_hub/hub/adapter/transformers/transformers_hub.py
+++ b/waffle_hub/hub/adapter/transformers/transformers_hub.py
@@ -35,7 +35,7 @@ from waffle_hub.hub.adapter.transformers.train_input_helper import (
 )
 from waffle_hub.hub.model.wrapper import ModelWrapper
 from waffle_hub.schema.configs import TrainConfig
-from waffle_hub.utils.working_info_logger import TrainingInfoLogger
+from waffle_hub.utils.running_status_logger import TrainingStatusLogger
 
 from .config import DEFAULT_PARAMS, MODEL_TYPES
 
@@ -205,7 +205,7 @@ class TransformersHub(Hub):
             device=cfg.device,
         )
 
-    def training(self, cfg: TrainConfig, info_logger: TrainingInfoLogger):
+    def training(self, cfg: TrainConfig, status_logger: TrainingStatusLogger):
         trainer = Trainer(
             model=cfg.train_input.model,
             args=cfg.train_input.training_args,

--- a/waffle_hub/hub/adapter/ultralytics/ultralytics_hub.py
+++ b/waffle_hub/hub/adapter/ultralytics/ultralytics_hub.py
@@ -20,7 +20,7 @@ from waffle_hub.hub import Hub
 from waffle_hub.hub.model.wrapper import ModelWrapper
 from waffle_hub.schema.configs import TrainConfig
 from waffle_hub.utils.process import run_python_file
-from waffle_hub.utils.working_info_logger import TrainingInfoLogger
+from waffle_hub.utils.running_status_logger import TrainingStatusLogger
 
 from .config import DEFAULT_PARAMS, MODEL_TYPES, TASK_MAP
 
@@ -283,7 +283,7 @@ class UltralyticsHub(Hub):
                 "letter_box False is not supported for Object Detection and Segmentation."
             )
 
-    def training(self, cfg: TrainConfig, info_logger: TrainingInfoLogger):
+    def training(self, cfg: TrainConfig, status_logger: TrainingStatusLogger):
         params = {
             "data": str(cfg.dataset_path).replace("\\", "/"),
             "epochs": cfg.epochs,

--- a/waffle_hub/hub/hub.py
+++ b/waffle_hub/hub/hub.py
@@ -852,22 +852,26 @@ class Hub:
             return []
         return io.load_json(self.evaluate_file)
 
-    def get_inference_result(self) -> list[dict]:
+    def get_inference_result(self) -> list[dict[str, list]]:
         """Get inference result from inference file.
 
         Example:
             >>> hub.get_inference_result()
             [
                 {
-                    "id": "00000001",
-                    "category": "person",
-                    "bbox": [0.1, 0.2, 0.3, 0.4],
-                    "score": 0.9,
+                    "file_name": [
+                        "category_id": 1,
+                        "bbox": [0.1, 0.2, 0.3, 0.4],
+                        "score": 0.9,
+                        "area": xxx,
+                        "iscrowd": 0,
+                        ]
                 },
+                ...
             ]
 
         Returns:
-            list[dict]: inference result
+            list[dict[str, list]]: inference result
         """
         if not self.inference_file.exists():
             return []

--- a/waffle_hub/hub/hub.py
+++ b/waffle_hub/hub/hub.py
@@ -46,11 +46,11 @@ from waffle_hub.schema.result import (
     InferenceResult,
     TrainResult,
 )
-from waffle_hub.schema.working_info import (
-    EvaluatingInfo,
-    ExportingInfo,
-    InferencingInfo,
-    TrainingInfo,
+from waffle_hub.schema.running_status import (
+    EvaluatingStatus,
+    ExportingStatus,
+    InferencingStatus,
+    TrainingStatus,
 )
 from waffle_hub.utils.data import (
     IMAGE_EXTS,
@@ -62,11 +62,11 @@ from waffle_hub.utils.draw import draw_results
 from waffle_hub.utils.evaluate import evaluate_function
 from waffle_hub.utils.memory import device_context
 from waffle_hub.utils.metric_logger import MetricLogger
-from waffle_hub.utils.working_info_logger import (
-    EvaluatingInfoLogger,
-    ExportingInfoLogger,
-    InferencingInfoLogger,
-    TrainingInfoLogger,
+from waffle_hub.utils.running_status_logger import (
+    EvaluatingStatusLogger,
+    ExportingStatusLogger,
+    InferencingStatusLogger,
+    TrainingStatusLogger,
 )
 
 logger = logging.getLogger(__name__)
@@ -111,12 +111,12 @@ class Hub:
     # export results
     ONNX_FILE = "weights/model.onnx"
 
-    # working info file
-    WORKING_INFO_DIR = Path("working_infos")
-    TRAINING_INFO_FILE = WORKING_INFO_DIR / "training_info.json"
-    EVALUATING_INFO_FILE = WORKING_INFO_DIR / "evaluating_info.json"
-    INFERENCING_INFO_FILE = WORKING_INFO_DIR / "inferencing_info.json"
-    EXPORTING_ONNX_INFO_FILE = WORKING_INFO_DIR / "exporting_onnx_info.json"
+    # running status file
+    RUNNING_STATUS_DIR = Path("running_status")
+    TRAINING_STATUS_FILE = RUNNING_STATUS_DIR / "training_status.json"
+    EVALUATING_STATUS_FILE = RUNNING_STATUS_DIR / "evaluating_status.json"
+    INFERENCING_STATUS_FILE = RUNNING_STATUS_DIR / "inferencing_status.json"
+    EXPORTING_ONNX_STATUS_FILE = RUNNING_STATUS_DIR / "exporting_onnx_status.json"
 
     def __init__(
         self,
@@ -628,9 +628,9 @@ class Hub:
         return self.hub_dir / Hub.WEIGHTS_DIR
 
     @cached_property
-    def working_info_dir(self) -> Path:
-        """Working Info Directory"""
-        return self.hub_dir / Hub.WORKING_INFO_DIR
+    def running_status_dir(self) -> Path:
+        """Running status Directory"""
+        return self.hub_dir / Hub.RUNNING_STATUS_DIR
 
     @cached_property
     def inference_dir(self) -> Path:
@@ -688,24 +688,24 @@ class Hub:
         return self.hub_dir / f"{self.name}.waffle"
 
     @cached_property
-    def training_info_file(self) -> Path:
-        """Training Info Json File"""
-        return self.hub_dir / Hub.TRAINING_INFO_FILE
+    def training_status_file(self) -> Path:
+        """Training status Json File"""
+        return self.hub_dir / Hub.TRAINING_STATUS_FILE
 
     @cached_property
-    def evaluating_info_file(self) -> Path:
-        """Evaluating Info Json File"""
-        return self.hub_dir / Hub.EVALUATING_INFO_FILE
+    def evaluating_status_file(self) -> Path:
+        """Evaluating status Json File"""
+        return self.hub_dir / Hub.EVALUATING_STATUS_FILE
 
     @cached_property
-    def inferencing_info_file(self) -> Path:
-        """Inferencing Info Json File"""
-        return self.hub_dir / Hub.INFERENCING_INFO_FILE
+    def inferencing_status_file(self) -> Path:
+        """Inferencing status Json File"""
+        return self.hub_dir / Hub.INFERENCING_STATUS_FILE
 
     @cached_property
-    def exporting_onnx_info_file(self) -> Path:
-        """Exporting Info Json File"""
-        return self.hub_dir / Hub.EXPORTING_ONNX_INFO_FILE
+    def exporting_onnx_status_file(self) -> Path:
+        """Exporting status Json File"""
+        return self.hub_dir / Hub.EXPORTING_ONNX_STATUS_FILE
 
     # common functions
     def delete_hub(self):
@@ -724,8 +724,18 @@ class Hub:
         Returns:
             bool: True if all files are exist else False
         """
-        if not self.get_training_info().status in [TrainStatus.SUCCESS, TrainStatus.STOPPED]:
-            raise ValueError("Train first! hub.train(...).")
+        # TODO : waffle version check. this is quick fix.
+        status = self.get_training_status()
+        if status is None:
+            warnings.warn("This model is trained with waffle-hub < 0.2.15. Please retrain.")
+            if not (self.model_config_file.exists() and self.best_ckpt_file.exists()):
+                raise ValueError("Train first! hub.train(...).")
+        else:
+            if not self.get_training_status().status_desc in [
+                TrainStatus.SUCCESS,
+                TrainStatus.STOPPED,
+            ]:
+                raise ValueError("Train first! hub.train(...).")
         return True
 
     def get_train_config(self) -> TrainConfig:
@@ -807,10 +817,8 @@ class Hub:
             list[dict]: metrics per epoch
         """
         if not self.metric_file.exists():
-            raise FileNotFoundError("Metric file is not exist. Train first!")
-
-        if not self.evaluate_file.exists():
-            raise FileNotFoundError("Evaluate file is not exist. Train first!")
+            warnings.warn("Metric file is not exist. Train first!")
+            return []
 
         return io.load_json(self.metric_file)
 
@@ -830,6 +838,7 @@ class Hub:
             dict: evaluate result
         """
         if not self.evaluate_file.exists():
+            warnings.warn("Evaluate file is not exist. Evaluate first!")
             return []
         return io.load_json(self.evaluate_file)
 
@@ -854,11 +863,95 @@ class Hub:
             return []
         return io.load_json(self.inference_file)
 
-    def get_training_info(self) -> TrainingInfo:
-        """Get training info from training info file.
+    def get_training_status(self) -> TrainingStatus:
+        """Get training Status from training Status file.
 
         Example:
-            >>> hub.get_training_info()
+            >>> hub.get_training_Status()
+            {
+                "status_desc": Literal["INIT", "RUNNING", "SUCCESS", "FAILED", "STOPPED"],
+                "error_type": String,
+                "error_msg": String,
+                "step": Integer,
+                "total_Step": Integer,
+            }
+
+        Raises:
+            FileNotFoundError: if training Status file is not exist
+
+        Returns:
+            TrainingStatus: training Status
+        """
+        if not self.training_status_file.exists():
+            warnings.warn(
+                "Training status file is not exist. Train first! or Check waffle-hub > 0.2.15."
+            )
+            return None
+            # raise FileNotFoundError("Training status file is not exist. Train first!")
+
+        return TrainingStatus.load(self.training_status_file)
+
+    def get_evaluating_status(self) -> EvaluatingStatus:
+        """Get evaluating status from evaluating status file.
+
+        Example:
+            >>> hub.get_evaluating_status()
+            {
+                "status_desc": Literal["INIT", "RUNNING", "SUCCESS", "FAILED", "STOPPED"],
+                "error_type": String,
+                "error_msg": String,
+                "step": Integer,
+                "total_Step": Integer,
+            }
+
+        Raises:
+            FileNotFoundError: if evaluating status file is not exist
+
+        Returns:
+            EvaluatingStatus: evaluating status
+        """
+        if not self.evaluating_status_file.exists():
+            warnings.warn(
+                "Evaluating status file is not exist. Evaluate first! or Check waffle-hub > 0.2.15."
+            )
+            return None
+            # raise FileNotFoundError("Evaluating status file is not exist. Evaluate first!")
+
+        return EvaluatingStatus.load(self.evaluating_status_file)
+
+    def get_inferencing_status(self) -> InferencingStatus:
+        """Get inferencing status from inferencing status file.
+
+        Example:
+            >>> hub.get_inferencing_status()
+            {
+                "status_desc": Literal["INIT", "RUNNING", "SUCCESS", "FAILED", "STOPPED"],
+                "error_type": String,
+                "error_msg": String,
+                "step": Integer,
+                "total_Step": Integer,
+            }
+
+        Raises:
+            FileNotFoundError: if inferencing status file is not exist
+
+        Returns:
+            InferencingStatus: inferencing status
+        """
+        if not self.inferencing_status_file.exists():
+            warnings.warn(
+                "Inferencing status file is not exist. Inference first! or Check waffle-hub > 0.2.15."
+            )
+            return None
+            # raise FileNotFoundError("Inferencing status file is not exist. Infer first!")
+
+        return InferencingStatus.load(self.inferencing_status_file)
+
+    def get_exporting_onnx_status(self) -> ExportingStatus:
+        """Get exporting status from exporting status file.
+
+        Example:
+            >>> hub.get_exporting_onnx_status()
             {
                 "status": Literal["INIT", "RUNNING", "SUCCESS", "FAILED", "STOPPED"],
                 "error_type": String,
@@ -868,87 +961,19 @@ class Hub:
             }
 
         Raises:
-            FileNotFoundError: if training info file is not exist
+            FileNotFoundError: if exporting status file is not exist
 
         Returns:
-            TrainingInfo: training info
+            ExportingStatus: exporting status
         """
-        if not self.training_info_file.exists():
-            raise FileNotFoundError("Training info file is not exist. Train first!")
+        if not self.exporting_onnx_status_file.exists():
+            warnings.warn(
+                "Exporting status file is not exist. Export_onnx first! or Check waffle-hub > 0.2.15."
+            )
+            return None
+            # raise FileNotFoundError("Exporting status file is not exist. Export_onnx first!")
 
-        return TrainingInfo.load(self.training_info_file)
-
-    def get_evaluating_info(self) -> EvaluatingInfo:
-        """Get evaluating info from evaluating info file.
-
-        Example:
-            >>> hub.get_evaluating_info()
-            {
-                "status": Literal["INIT", "RUNNING", "SUCCESS", "FAILED", "STOPPED"],
-                "error_type": String,
-                "error_msg": String,
-                "step": Integer,
-                "total_Step": Integer,
-            }
-
-        Raises:
-            FileNotFoundError: if evaluating info file is not exist
-
-        Returns:
-            EvaluatingInfo: evaluating info
-        """
-        if not self.evaluating_info_file.exists():
-            raise FileNotFoundError("Evaluating info file is not exist. Evaluate first!")
-
-        return EvaluatingInfo.load(self.evaluating_info_file)
-
-    def get_inferencing_info(self) -> InferencingInfo:
-        """Get inferencing info from inferencing info file.
-
-        Example:
-            >>> hub.get_inferencing_info()
-            {
-                "status": Literal["INIT", "RUNNING", "SUCCESS", "FAILED", "STOPPED"],
-                "error_type": String,
-                "error_msg": String,
-                "step": Integer,
-                "total_Step": Integer,
-            }
-
-        Raises:
-            FileNotFoundError: if inferencing info file is not exist
-
-        Returns:
-            InferencingInfo: inferencing info
-        """
-        if not self.inferencing_info_file.exists():
-            raise FileNotFoundError("Inferencing info file is not exist. Infer first!")
-
-        return InferencingInfo.load(self.inferencing_info_file)
-
-    def get_exporting_onnx_info(self) -> ExportingInfo:
-        """Get exporting info from exporting info file.
-
-        Example:
-            >>> hub.get_exporting_onnx_info()
-            {
-                "status": Literal["INIT", "RUNNING", "SUCCESS", "FAILED", "STOPPED"],
-                "error_type": String,
-                "error_msg": String,
-                "step": Integer,
-                "total_Step": Integer,
-            }
-
-        Raises:
-            FileNotFoundError: if exporting info file is not exist
-
-        Returns:
-            ExportingInfo: exporting info
-        """
-        if not self.exporting_onnx_info_file.exists():
-            raise FileNotFoundError("Exporting info file is not exist. Export_onnx first!")
-
-        return ExportingInfo.load(self.exporting_onnx_info_file)
+        return ExportingStatus.load(self.exporting_onnx_status_file)
 
     # Hub Utils
     def get_image_loader(self) -> tuple[torch.Tensor, ImageInfo]:
@@ -1033,7 +1058,7 @@ class Hub:
     def save_train_config(self, cfg: TrainConfig):
         cfg.save_yaml(self.train_config_file)
 
-    def training(self, cfg: TrainConfig, info_logger: TrainingInfoLogger):
+    def training(self, cfg: TrainConfig, status_logger: TrainingStatusLogger):
         pass
 
     def on_train_end(
@@ -1111,14 +1136,14 @@ class Hub:
             TrainResult: train result
         """
         # status
-        info_logger = TrainingInfoLogger(save_path=self.training_info_file)
+        status_logger = TrainingStatusLogger(save_path=self.training_status_file)
         metric_logger = MetricLogger(
             name=self.name,
             log_dir=self.train_log_dir,
             func=self.get_metrics,
             interval=10,
             prefix="waffle",
-            info_logger=info_logger,
+            status_logger=status_logger,
         )
         try:
             # parse dataset
@@ -1214,31 +1239,31 @@ class Hub:
                         )
 
             result = TrainResult()
-            info_logger.set_total_step(cfg.epochs)
+            status_logger.set_total_step(cfg.epochs)
 
             # train run
-            info_logger.set_running()
+            status_logger.set_running()
             metric_logger.start()
             self.before_train(cfg)
             self.on_train_start(cfg)
             self.save_train_config(cfg)
-            self.training(cfg, info_logger)
+            self.training(cfg, status_logger)
             self.on_train_end(cfg)
             self.after_train(cfg, result)
-            info_logger.set_success()
+            status_logger.set_success()
             metric_logger.stop()
         except FileExistsError as e:
-            info_logger.set_failed(e)
+            status_logger.set_failed(e)
             metric_logger.stop()
             raise e
         except (KeyboardInterrupt, SystemExit) as e:
-            info_logger.set_stopped(e)
+            status_logger.set_stopped(e)
             metric_logger.stop()
             if self.artifact_dir.exists():
                 self.on_train_end(cfg)
             raise e
         except Exception as e:
-            info_logger.set_failed(e)
+            status_logger.set_failed(e)
             metric_logger.stop()
             if self.artifact_dir.exists():
                 io.remove_directory(self.artifact_dir)
@@ -1273,7 +1298,9 @@ class Hub:
     def on_evaluate_start(self, cfg: EvaluateConfig):
         pass
 
-    def evaluating(self, cfg: EvaluateConfig, info_logger: EvaluatingInfoLogger, dataset: Dataset):
+    def evaluating(
+        self, cfg: EvaluateConfig, status_logger: EvaluatingStatusLogger, dataset: Dataset
+    ):
         device = cfg.device
 
         model = self.get_model().to(device)
@@ -1288,7 +1315,7 @@ class Hub:
 
         result_parser = get_parser(self.task)(**cfg.to_dict(), categories=self.categories)
 
-        info_logger.set_total_step(len(dataloader) + 1)
+        status_logger.set_total_step(len(dataloader) + 1)
 
         preds = []
         labels = []
@@ -1301,7 +1328,7 @@ class Hub:
             preds.extend(result_batch)
             labels.extend(annotations)
 
-            info_logger.set_current_step(i)
+            status_logger.set_current_step(i)
 
         metrics = evaluate_function(
             preds, labels, self.task, len(self.categories), image_size=cfg.image_size
@@ -1389,7 +1416,7 @@ class Hub:
             EvaluateResult: evaluate result
         """
         # status
-        info_logger = EvaluatingInfoLogger(save_path=self.evaluating_info_file)
+        status_logger = EvaluatingStatusLogger(save_path=self.evaluating_status_file)
 
         try:
             if "," in device:
@@ -1432,18 +1459,18 @@ class Hub:
             result = EvaluateResult()
 
             # evaluate run
-            info_logger.set_running()
+            status_logger.set_running()
             self.before_evaluate(cfg, dataset)
             self.on_evaluate_start(cfg)
-            self.evaluating(cfg, info_logger, dataset)
+            self.evaluating(cfg, status_logger, dataset)
             self.on_evaluate_end(cfg)
             self.after_evaluate(cfg, result)
-            info_logger.set_success()
+            status_logger.set_success()
         except (KeyboardInterrupt, SystemExit) as e:
-            info_logger.set_stopped(e)
+            status_logger.set_stopped(e)
             raise e
         except Exception as e:
-            info_logger.set_failed(e)
+            status_logger.set_failed(e)
             if self.evaluate_file.exists():
                 io.remove_file(self.evaluate_file)
             raise e
@@ -1457,7 +1484,7 @@ class Hub:
     def on_inference_start(self, cfg: InferenceConfig):
         pass
 
-    def inferencing(self, cfg: InferenceConfig, info_logger: InferencingInfoLogger):
+    def inferencing(self, cfg: InferenceConfig, status_logger: InferencingStatusLogger):
         device = cfg.device
         model = self.get_model().to(device)
         result_parser = get_parser(self.task)(**cfg.to_dict(), categories=self.categories)
@@ -1479,7 +1506,7 @@ class Hub:
             writer = None
 
         results = []
-        info_logger.set_total_step(len(dataloader) + 1)
+        status_logger.set_total_step(len(dataloader) + 1)
         for i, (images, image_infos) in tqdm.tqdm(
             enumerate(dataloader, start=1), total=len(dataloader)
         ):
@@ -1528,7 +1555,7 @@ class Hub:
                     cv2.imshow("result", draw)
                     cv2.waitKey(1)
 
-            info_logger.set_current_step(i)
+            status_logger.set_current_step(i)
 
         if cfg.draw and cfg.source_type == "video":
             writer.release()
@@ -1611,7 +1638,7 @@ class Hub:
             InferenceResult: inference result
         """
         # status controller
-        info_logger = InferencingInfoLogger(save_path=self.inferencing_info_file)
+        status_logger = InferencingStatusLogger(save_path=self.inferencing_status_file)
 
         try:
             # inference settings
@@ -1667,18 +1694,18 @@ class Hub:
             result = InferenceResult()
 
             # run inference
-            info_logger.set_running()
+            status_logger.set_running()
             self.before_inference(cfg)
             self.on_inference_start(cfg)
-            self.inferencing(cfg, info_logger)
+            self.inferencing(cfg, status_logger)
             self.on_inference_end(cfg)
             self.after_inference(cfg, result)
-            info_logger.set_success()
+            status_logger.set_success()
         except (KeyboardInterrupt, SystemExit) as e:
-            info_logger.set_stopped(e)
+            status_logger.set_stopped(e)
             raise e
         except Exception as e:
-            info_logger.set_failed(e)
+            status_logger.set_failed(e)
             if self.inference_dir.exists():
                 io.remove_directory(self.inference_dir)
             raise e
@@ -1692,7 +1719,7 @@ class Hub:
     def on_export_onnx_start(self, cfg: ExportOnnxConfig):
         pass
 
-    def exporting_onnx(self, cfg: ExportOnnxConfig, info_logger: ExportingInfoLogger) -> str:
+    def exporting_onnx(self, cfg: ExportOnnxConfig, status_logger: ExportingStatusLogger) -> str:
         image_size = cfg.image_size
         image_size = [image_size, image_size] if isinstance(image_size, int) else image_size
 
@@ -1773,7 +1800,7 @@ class Hub:
         self.check_train_sanity()
 
         # status controller
-        info_logger = ExportingInfoLogger(save_path=self.exporting_onnx_info_file)
+        status_logger = ExportingStatusLogger(save_path=self.exporting_onnx_status_file)
 
         try:
             # overwrite training config
@@ -1792,18 +1819,18 @@ class Hub:
             result = ExportOnnxResult()
 
             # run export onnx
-            info_logger.set_running()
+            status_logger.set_running()
             self.before_export_onnx(cfg)
             self.on_export_onnx_start(cfg)
-            self.exporting_onnx(cfg, info_logger)
+            self.exporting_onnx(cfg, status_logger)
             self.on_export_onnx_end(cfg)
             self.after_export_onnx(cfg, result)
-            info_logger.set_success()
+            status_logger.set_success()
         except (KeyboardInterrupt, SystemExit) as e:
-            info_logger.set_stopped(e)
+            status_logger.set_stopped(e)
             raise e
         except Exception as e:
-            info_logger.set_failed(e)
+            status_logger.set_failed(e)
             if self.onnx_file.exists():
                 io.remove_file(self.onnx_file)
             raise e
@@ -1902,7 +1929,7 @@ class Hub:
         result = ExportWaffleResult()
 
         try:
-            io.zip([self.config_dir, self.weights_dir, self.working_info_dir], self.waffle_file)
+            io.zip([self.config_dir, self.weights_dir, self.running_status_dir], self.waffle_file)
             result.waffle_file = self.waffle_file
         except Exception as e:
             if self.waffle_file.exists():

--- a/waffle_hub/schema/running_status.py
+++ b/waffle_hub/schema/running_status.py
@@ -11,12 +11,12 @@ from waffle_hub import (
 )
 from waffle_hub.schema.base_schema import BaseSchema
 
-STATUS_TYPE = TypeVar("STATUS_TYPE", bound=BaseEnum)
+STATUS_DESC_TYPE = TypeVar("STATUS_DESC_TYPE", bound=BaseEnum)
 
 
 @dataclass
-class BaseRunningStatus(Generic[STATUS_TYPE], BaseSchema):
-    status_desc: STATUS_TYPE = None
+class BaseRunningStatus(Generic[STATUS_DESC_TYPE], BaseSchema):
+    status_desc: STATUS_DESC_TYPE = None
     error_type: str = None
     error_msg: str = None
     step: int = None

--- a/waffle_hub/schema/running_status.py
+++ b/waffle_hub/schema/running_status.py
@@ -14,15 +14,15 @@ STATUS_TYPE = TypeVar("STATUS_TYPE", bound=BaseEnum)
 
 
 @dataclass
-class BaseWorkingInfo(Generic[STATUS_TYPE], BaseSchema):
-    status: STATUS_TYPE = None
+class BaseRunningStatus(Generic[STATUS_TYPE], BaseSchema):
+    status_desc: STATUS_TYPE = None
     error_type: str = None
     error_msg: str = None
     step: int = None
     total_step: int = None
 
     def __setattr__(self, name, value):
-        if name == "status":
+        if name == "status_desc":
             if not (value is None or value in self.__class__.__orig_bases__[0].__args__[0]):
                 raise ValueError(
                     f"status must be one of {self.__class__.__orig_bases__[0].__args__[0]}"
@@ -31,20 +31,20 @@ class BaseWorkingInfo(Generic[STATUS_TYPE], BaseSchema):
 
 
 @dataclass
-class TrainingInfo(BaseWorkingInfo[TrainStatus]):
+class TrainingStatus(BaseRunningStatus[TrainStatus]):
     pass
 
 
 @dataclass
-class EvaluatingInfo(BaseWorkingInfo[EvaluateStatus]):
+class EvaluatingStatus(BaseRunningStatus[EvaluateStatus]):
     pass
 
 
 @dataclass
-class InferencingInfo(BaseWorkingInfo[InferenceStatus]):
+class InferencingStatus(BaseRunningStatus[InferenceStatus]):
     pass
 
 
 @dataclass
-class ExportingInfo(BaseWorkingInfo[ExportStatus]):
+class ExportingStatus(BaseRunningStatus[ExportStatus]):
     pass

--- a/waffle_hub/schema/running_status.py
+++ b/waffle_hub/schema/running_status.py
@@ -3,10 +3,11 @@ from typing import Generic, TypeVar
 
 from waffle_hub import (
     BaseEnum,
-    EvaluateStatus,
-    ExportStatus,
-    InferenceStatus,
-    TrainStatus,
+    EvaluateStatusDesc,
+    ExportOnnxStatusDesc,
+    ExportWaffleStatusDesc,
+    InferenceStatusDesc,
+    TrainStatusDesc,
 )
 from waffle_hub.schema.base_schema import BaseSchema
 
@@ -31,20 +32,25 @@ class BaseRunningStatus(Generic[STATUS_TYPE], BaseSchema):
 
 
 @dataclass
-class TrainingStatus(BaseRunningStatus[TrainStatus]):
+class TrainingStatus(BaseRunningStatus[TrainStatusDesc]):
     pass
 
 
 @dataclass
-class EvaluatingStatus(BaseRunningStatus[EvaluateStatus]):
+class EvaluatingStatus(BaseRunningStatus[EvaluateStatusDesc]):
     pass
 
 
 @dataclass
-class InferencingStatus(BaseRunningStatus[InferenceStatus]):
+class InferencingStatus(BaseRunningStatus[InferenceStatusDesc]):
     pass
 
 
 @dataclass
-class ExportingStatus(BaseRunningStatus[ExportStatus]):
+class ExportingOnnxStatus(BaseRunningStatus[ExportOnnxStatusDesc]):
+    pass
+
+
+@dataclass
+class ExportingWaffleStatus(BaseRunningStatus[ExportWaffleStatusDesc]):
     pass

--- a/waffle_hub/utils/metric_logger.py
+++ b/waffle_hub/utils/metric_logger.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from threading import Thread
 from typing import Union
 
-from waffle_hub.utils.working_info_logger import RunningInfoLogger
+from waffle_hub.utils.running_status_logger import RunningStatusLogger
 
 __all__ = ["MetricLogger"]
 
@@ -106,7 +106,7 @@ class MetricLogger:
         log_dir: Union[str, Path],
         func: callable,
         interval: float,
-        info_logger: RunningInfoLogger,
+        status_logger: RunningStatusLogger,
         prefix: str = "",
         **kwargs,
     ):
@@ -119,7 +119,7 @@ class MetricLogger:
                 func should return a list of metrics.
                 e.g. func() -> [[{"tag": "value}, ...], ...]
             interval (float): The interval to log metrics. (seconds)
-            info_logger (RunningInfoLogger): The logger class for step.
+            status_logger (RunningStatusLogger): The logger class for step.
             prefix (str, optional): The prefix of the log file. Defaults to "".
             kwargs: The arguments for the metric logger.
         """
@@ -129,7 +129,7 @@ class MetricLogger:
         self.func = func
         self.interval = float(interval)
         self.prefix = str(prefix)
-        self.info_logger = info_logger
+        self.status_logger = status_logger
         self.kwargs = kwargs
 
         self.loggers = [
@@ -191,7 +191,7 @@ class MetricLogger:
         """Log metrics."""
         metrics_per_epoch = self.func()
         current_step = len(metrics_per_epoch)
-        self.info_logger.set_current_step(current_step)
+        self.status_logger.set_current_step(current_step)
         for step in range(self._last_step, current_step):
             # metrics is a list of dict
             # e.g. [{"tag": "value"}, ...]

--- a/waffle_hub/utils/running_status_logger.py
+++ b/waffle_hub/utils/running_status_logger.py
@@ -8,7 +8,7 @@ from waffle_hub import (
     TrainStatusDesc,
 )
 from waffle_hub.schema.running_status import (
-    STATUS_TYPE,
+    STATUS_DESC_TYPE,
     BaseRunningStatus,
     EvaluatingStatus,
     ExportingOnnxStatus,
@@ -30,7 +30,7 @@ class RunningStatusLogger:
     def save(self):
         self.running_status.save_json(save_path=self.save_path)
 
-    def set_status(self, status: STATUS_TYPE):
+    def set_status(self, status: STATUS_DESC_TYPE):
         self.running_status.status_desc = status
         self.save()
 

--- a/waffle_hub/utils/running_status_logger.py
+++ b/waffle_hub/utils/running_status_logger.py
@@ -1,60 +1,60 @@
 from pathlib import Path
 
 from waffle_hub import EvaluateStatus, ExportStatus, InferenceStatus, TrainStatus
-from waffle_hub.schema.working_info import (
+from waffle_hub.schema.running_status import (
     STATUS_TYPE,
-    BaseWorkingInfo,
-    EvaluatingInfo,
-    ExportingInfo,
-    InferencingInfo,
-    TrainingInfo,
+    BaseRunningStatus,
+    EvaluatingStatus,
+    ExportingStatus,
+    InferencingStatus,
+    TrainingStatus,
 )
 
 
-class RunningInfoLogger:
-    working_info: BaseWorkingInfo = None
+class RunningStatusLogger:
+    running_status: BaseRunningStatus = None
 
-    def __init__(self, working_info: BaseWorkingInfo, save_path: Path):
-        self.working_info = working_info
-        if self.working_info is None:
-            raise NotImplementedError("working_info must be not None")
+    def __init__(self, running_status: BaseRunningStatus, save_path: Path):
+        self.running_status = running_status
+        if self.running_status is None:
+            raise NotImplementedError("running_status must be not None")
         self.save_path = save_path
 
     def save(self):
-        self.working_info.save_json(save_path=self.save_path)
+        self.running_status.save_json(save_path=self.save_path)
 
     def set_status(self, status: STATUS_TYPE):
-        self.working_info.status = status
+        self.running_status.status_desc = status
         self.save()
 
     def set_error(self, e: Exception = None):
-        self.working_info.error_type = e.__class__.__name__
-        self.working_info.error_msg = e
+        self.running_status.error_type = e.__class__.__name__
+        self.running_status.error_msg = e
         self.save()
 
     def clear_error(self):
-        self.working_info.error_type = None
-        self.working_info.error_msg = None
+        self.running_status.error_type = None
+        self.running_status.error_msg = None
         self.save()
 
     def clear_step(self):
-        self.working_info.step = 0
-        self.working_info.total_step = 0
+        self.running_status.step = 0
+        self.running_status.total_step = 0
         self.save()
 
     def set_total_step(self, total_step: int):
-        self.working_info.total_step = total_step
-        self.working_info.step = 0
+        self.running_status.total_step = total_step
+        self.running_status.step = 0
         self.save()
 
     def set_current_step(self, step: int):
-        self.working_info.step = step
+        self.running_status.step = step
         self.save()
 
 
-class TrainingInfoLogger(RunningInfoLogger):
+class TrainingStatusLogger(RunningStatusLogger):
     def __init__(self, save_path: Path):
-        super().__init__(TrainingInfo(), save_path)
+        super().__init__(TrainingStatus(), save_path)
         self.set_init()
 
     def set_init(self):
@@ -68,7 +68,7 @@ class TrainingInfoLogger(RunningInfoLogger):
 
     def set_success(self):
         self.clear_error()
-        self.working_info.step = self.working_info.total_step
+        self.running_status.step = self.running_status.total_step
         self.set_status(TrainStatus.SUCCESS)
 
     def set_running(self):
@@ -79,9 +79,9 @@ class TrainingInfoLogger(RunningInfoLogger):
         self.set_status(TrainStatus.STOPPED)
 
 
-class EvaluatingInfoLogger(RunningInfoLogger):
+class EvaluatingStatusLogger(RunningStatusLogger):
     def __init__(self, save_path: Path):
-        super().__init__(EvaluatingInfo(), save_path)
+        super().__init__(EvaluatingStatus(), save_path)
         self.set_init()
 
     def set_init(self):
@@ -95,7 +95,7 @@ class EvaluatingInfoLogger(RunningInfoLogger):
 
     def set_success(self):
         self.clear_error()
-        self.working_info.step = self.working_info.total_step
+        self.running_status.step = self.running_status.total_step
         self.set_status(EvaluateStatus.SUCCESS)
 
     def set_running(self):
@@ -106,9 +106,9 @@ class EvaluatingInfoLogger(RunningInfoLogger):
         self.set_status(EvaluateStatus.STOPPED)
 
 
-class InferencingInfoLogger(RunningInfoLogger):
+class InferencingStatusLogger(RunningStatusLogger):
     def __init__(self, save_path: Path):
-        super().__init__(InferencingInfo(), save_path)
+        super().__init__(InferencingStatus(), save_path)
         self.set_init()
 
     def set_init(self):
@@ -122,7 +122,7 @@ class InferencingInfoLogger(RunningInfoLogger):
 
     def set_success(self):
         self.clear_error()
-        self.working_info.step = self.working_info.total_step
+        self.running_status.step = self.running_status.total_step
         self.set_status(InferenceStatus.SUCCESS)
 
     def set_running(self):
@@ -133,9 +133,9 @@ class InferencingInfoLogger(RunningInfoLogger):
         self.set_status(InferenceStatus.STOPPED)
 
 
-class ExportingInfoLogger(RunningInfoLogger):
+class ExportingStatusLogger(RunningStatusLogger):
     def __init__(self, save_path: Path):
-        super().__init__(ExportingInfo(), save_path)
+        super().__init__(ExportingStatus(), save_path)
         self.set_init()
 
     def set_init(self):
@@ -149,7 +149,7 @@ class ExportingInfoLogger(RunningInfoLogger):
 
     def set_success(self):
         self.clear_error()
-        self.working_info.step = self.working_info.total_step
+        self.running_status.step = self.running_status.total_step
         self.set_status(ExportStatus.SUCCESS)
 
     def set_running(self):

--- a/waffle_hub/utils/running_status_logger.py
+++ b/waffle_hub/utils/running_status_logger.py
@@ -1,11 +1,18 @@
 from pathlib import Path
 
-from waffle_hub import EvaluateStatus, ExportStatus, InferenceStatus, TrainStatus
+from waffle_hub import (
+    EvaluateStatusDesc,
+    ExportOnnxStatusDesc,
+    ExportWaffleStatusDesc,
+    InferenceStatusDesc,
+    TrainStatusDesc,
+)
 from waffle_hub.schema.running_status import (
     STATUS_TYPE,
     BaseRunningStatus,
     EvaluatingStatus,
-    ExportingStatus,
+    ExportingOnnxStatus,
+    ExportingWaffleStatus,
     InferencingStatus,
     TrainingStatus,
 )
@@ -60,23 +67,23 @@ class TrainingStatusLogger(RunningStatusLogger):
     def set_init(self):
         self.clear_error()
         self.clear_step()
-        self.set_status(TrainStatus.INIT)
+        self.set_status(TrainStatusDesc.INIT)
 
     def set_failed(self, e):
         self.set_error(e)
-        self.set_status(TrainStatus.FAILED)
+        self.set_status(TrainStatusDesc.FAILED)
 
     def set_success(self):
         self.clear_error()
         self.running_status.step = self.running_status.total_step
-        self.set_status(TrainStatus.SUCCESS)
+        self.set_status(TrainStatusDesc.SUCCESS)
 
     def set_running(self):
-        self.set_status(TrainStatus.RUNNING)
+        self.set_status(TrainStatusDesc.RUNNING)
 
     def set_stopped(self, e):
         self.set_error(e)
-        self.set_status(TrainStatus.STOPPED)
+        self.set_status(TrainStatusDesc.STOPPED)
 
 
 class EvaluatingStatusLogger(RunningStatusLogger):
@@ -87,23 +94,23 @@ class EvaluatingStatusLogger(RunningStatusLogger):
     def set_init(self):
         self.clear_error()
         self.clear_step()
-        self.set_status(EvaluateStatus.INIT)
+        self.set_status(EvaluateStatusDesc.INIT)
 
     def set_failed(self, e):
         self.set_error(e)
-        self.set_status(EvaluateStatus.FAILED)
+        self.set_status(EvaluateStatusDesc.FAILED)
 
     def set_success(self):
         self.clear_error()
         self.running_status.step = self.running_status.total_step
-        self.set_status(EvaluateStatus.SUCCESS)
+        self.set_status(EvaluateStatusDesc.SUCCESS)
 
     def set_running(self):
-        self.set_status(EvaluateStatus.RUNNING)
+        self.set_status(EvaluateStatusDesc.RUNNING)
 
     def set_stopped(self, e):
         self.set_error(e)
-        self.set_status(EvaluateStatus.STOPPED)
+        self.set_status(EvaluateStatusDesc.STOPPED)
 
 
 class InferencingStatusLogger(RunningStatusLogger):
@@ -114,47 +121,74 @@ class InferencingStatusLogger(RunningStatusLogger):
     def set_init(self):
         self.clear_error()
         self.clear_step()
-        self.set_status(InferenceStatus.INIT)
+        self.set_status(InferenceStatusDesc.INIT)
 
     def set_failed(self, e):
         self.set_error(e)
-        self.set_status(InferenceStatus.FAILED)
+        self.set_status(InferenceStatusDesc.FAILED)
 
     def set_success(self):
         self.clear_error()
         self.running_status.step = self.running_status.total_step
-        self.set_status(InferenceStatus.SUCCESS)
+        self.set_status(InferenceStatusDesc.SUCCESS)
 
     def set_running(self):
-        self.set_status(InferenceStatus.RUNNING)
+        self.set_status(InferenceStatusDesc.RUNNING)
 
     def set_stopped(self, e):
         self.set_error(e)
-        self.set_status(InferenceStatus.STOPPED)
+        self.set_status(InferenceStatusDesc.STOPPED)
 
 
-class ExportingStatusLogger(RunningStatusLogger):
+class ExportingOnnxStatusLogger(RunningStatusLogger):
     def __init__(self, save_path: Path):
-        super().__init__(ExportingStatus(), save_path)
+        super().__init__(ExportingOnnxStatus(), save_path)
         self.set_init()
 
     def set_init(self):
         self.clear_error()
         self.clear_step()
-        self.set_status(ExportStatus.INIT)
+        self.set_status(ExportOnnxStatusDesc.INIT)
 
     def set_failed(self, e):
         self.set_error(e)
-        self.set_status(ExportStatus.FAILED)
+        self.set_status(ExportOnnxStatusDesc.FAILED)
 
     def set_success(self):
         self.clear_error()
         self.running_status.step = self.running_status.total_step
-        self.set_status(ExportStatus.SUCCESS)
+        self.set_status(ExportOnnxStatusDesc.SUCCESS)
 
     def set_running(self):
-        self.set_status(ExportStatus.RUNNING)
+        self.set_status(ExportOnnxStatusDesc.RUNNING)
 
     def set_stopped(self, e):
         self.set_error(e)
-        self.set_status(ExportStatus.STOPPED)
+        self.set_status(ExportOnnxStatusDesc.STOPPED)
+
+
+class ExportingWaffleStatusLogger(RunningStatusLogger):
+    def __init__(self, save_path: Path):
+        super().__init__(ExportingWaffleStatus(), save_path)
+        self.set_init()
+
+    def set_init(self):
+        self.clear_error()
+        self.clear_step()
+        self.set_status(ExportWaffleStatusDesc.INIT)
+
+    def set_failed(self, e):
+        self.set_error(e)
+        self.set_status(ExportWaffleStatusDesc.FAILED)
+
+    def set_success(self):
+        self.clear_error()
+        self.running_status.step = self.running_status.total_step
+        self.set_status(ExportWaffleStatusDesc.SUCCESS)
+
+    def set_running(self):
+        self.set_status(ExportWaffleStatusDesc.RUNNING)
+
+    def set_stopped(self, e):
+        self.set_error(e)
+        self.set_status(ExportWaffleStatusDesc.STOPPED)


### PR DESCRIPTION
- Changed
  - Status naming is changed
    - `working` -> `running`
    - `info` -> `status`
    - so, running_status json is modified like:
   `{"status_desc": Literal["INIT", "RUNNING", "SUCCESS", "FAILED", "STOPPED"],
	"error_type": String,
	"error_msg": String,
	"step": Integer,
	"total_Step": Integer}`
  - Hotfix `check_train_sanity` func
    - Fixed a bug that did not work for the results trained with`waffle-hub < 0.2.16.`

- BackLog
  - Waffle version management