### PR TITLE
add strict option to dataset export

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -5,7 +5,7 @@ import pytest
 from waffle_utils.file.io import load_json, save_json
 from waffle_utils.file.search import get_image_files
 
-from waffle_hub import TaskType
+from waffle_hub import DataType, TaskType
 from waffle_hub.dataset import Dataset
 from waffle_hub.schema.fields import Annotation, Category, Image
 from waffle_hub.utils.data import ImageDataset, LabeledDataset
@@ -277,6 +277,25 @@ def _export(dataset_name, task: TaskType, root_dir):
         assert len(dataset.get_images()) == len(import_ds.get_images())
 
 
+# bypass restirction
+def _export_bypass(dataset_name, data_type, root_dir):
+    # test restrict (bypassing validation)
+    clone = Dataset.clone(
+        dataset_name, dataset_name + "_clone", src_root_dir=root_dir, root_dir=root_dir
+    )
+    clone.add_categories(
+        Category(
+            category_id=len(clone.get_categories()) + 1,
+            name="dummy_category",
+            supercategory="object",
+        )
+    )
+    clone.create_index()
+    with pytest.raises(ValueError):
+        clone.export(data_type, restrict=True)
+    clone.export(data_type, restrict=False)
+
+
 # test dummy
 def _dummy(dataset_name, task: TaskType, image_num, category_num, unlabeled_image_num, root_dir):
     dataset = Dataset.dummy(
@@ -360,6 +379,7 @@ def _total_coco(dataset_name, task: TaskType, coco_path, root_dir):
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, task, root_dir)
+    _export_bypass(dataset_name, DataType.COCO, root_dir)
 
 
 @pytest.mark.parametrize(
@@ -390,6 +410,7 @@ def test_yolo_classification(yolo_classification_path: Path, tmpdir: Path):
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, TaskType.CLASSIFICATION, root_dir)
+    _export_bypass(dataset_name, DataType.ULTRALYTICS, root_dir)
 
 
 def test_yolo_object_detection(yolo_object_detection_path: Path, tmpdir: Path):
@@ -413,6 +434,7 @@ def test_yolo_object_detection(yolo_object_detection_path: Path, tmpdir: Path):
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, TaskType.OBJECT_DETECTION, root_dir)
+    _export_bypass(dataset_name, DataType.ULTRALYTICS, root_dir)
 
 
 def test_yolo_instance_segmentation(yolo_instance_segmentation_path: Path, tmpdir: Path):
@@ -436,6 +458,7 @@ def test_yolo_instance_segmentation(yolo_instance_segmentation_path: Path, tmpdi
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, TaskType.INSTANCE_SEGMENTATION, root_dir)
+    _export_bypass(dataset_name, DataType.ULTRALYTICS, root_dir)
 
 
 # test autocare_dlt
@@ -456,6 +479,7 @@ def _total_autocare_dlt(dataset_name, task: TaskType, coco_path, root_dir):
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, task, root_dir)
+    _export_bypass(dataset_name, DataType.AUTOCARE_DLT, root_dir)
 
 
 @pytest.mark.parametrize(
@@ -492,6 +516,7 @@ def _total_transformers(dataset_name, task: TaskType, transformers_path, root_di
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, task, root_dir)
+    _export_bypass(dataset_name, DataType.TRANSFORMERS, root_dir)
 
 
 def test_transformers(transformers_detection_path, transformers_classification_path, tmpdir):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -278,8 +278,8 @@ def _export(dataset_name, task: TaskType, root_dir):
 
 
 # bypass restirction
-def _export_bypass(dataset_name, data_type, root_dir):
-    # test restrict (bypassing validation)
+def _strict(dataset_name, data_type, root_dir):
+    # test strict (bypassing validation)
     clone = Dataset.clone(
         dataset_name, dataset_name + "_clone", src_root_dir=root_dir, root_dir=root_dir
     )
@@ -292,8 +292,12 @@ def _export_bypass(dataset_name, data_type, root_dir):
     )
     clone.create_index()
     with pytest.raises(ValueError):
-        clone.export(data_type, restrict=True)
-    clone.export(data_type, restrict=False)
+        clone.split(0.8, strict=True)
+    clone.split(0.8, strict=False)
+
+    with pytest.raises(ValueError):
+        clone.export(data_type, strict=True)
+    clone.export(data_type, strict=False)
 
 
 # test dummy
@@ -379,7 +383,7 @@ def _total_coco(dataset_name, task: TaskType, coco_path, root_dir):
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, task, root_dir)
-    _export_bypass(dataset_name, DataType.COCO, root_dir)
+    _strict(dataset_name, DataType.COCO, root_dir)
 
 
 @pytest.mark.parametrize(
@@ -410,7 +414,7 @@ def test_yolo_classification(yolo_classification_path: Path, tmpdir: Path):
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, TaskType.CLASSIFICATION, root_dir)
-    _export_bypass(dataset_name, DataType.ULTRALYTICS, root_dir)
+    _strict(dataset_name, DataType.ULTRALYTICS, root_dir)
 
 
 def test_yolo_object_detection(yolo_object_detection_path: Path, tmpdir: Path):
@@ -434,7 +438,7 @@ def test_yolo_object_detection(yolo_object_detection_path: Path, tmpdir: Path):
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, TaskType.OBJECT_DETECTION, root_dir)
-    _export_bypass(dataset_name, DataType.ULTRALYTICS, root_dir)
+    _strict(dataset_name, DataType.ULTRALYTICS, root_dir)
 
 
 def test_yolo_instance_segmentation(yolo_instance_segmentation_path: Path, tmpdir: Path):
@@ -458,7 +462,7 @@ def test_yolo_instance_segmentation(yolo_instance_segmentation_path: Path, tmpdi
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, TaskType.INSTANCE_SEGMENTATION, root_dir)
-    _export_bypass(dataset_name, DataType.ULTRALYTICS, root_dir)
+    _strict(dataset_name, DataType.ULTRALYTICS, root_dir)
 
 
 # test autocare_dlt
@@ -479,7 +483,7 @@ def _total_autocare_dlt(dataset_name, task: TaskType, coco_path, root_dir):
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, task, root_dir)
-    _export_bypass(dataset_name, DataType.AUTOCARE_DLT, root_dir)
+    _strict(dataset_name, DataType.AUTOCARE_DLT, root_dir)
 
 
 @pytest.mark.parametrize(
@@ -516,7 +520,7 @@ def _total_transformers(dataset_name, task: TaskType, transformers_path, root_di
     _clone(dataset_name, root_dir)
     _split(dataset_name, root_dir)
     _export(dataset_name, task, root_dir)
-    _export_bypass(dataset_name, DataType.TRANSFORMERS, root_dir)
+    _strict(dataset_name, DataType.TRANSFORMERS, root_dir)
 
 
 def test_transformers(transformers_detection_path, transformers_classification_path, tmpdir):

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -1506,6 +1506,7 @@ class Dataset:
         test_ratio: float = 0.0,
         method: Union[str, SplitMethod] = SplitMethod.RANDOM,
         seed: int = 0,
+        strict: bool = True,
     ):
         """
         Split Dataset to train, validation, test, (unlabeled) sets.
@@ -1516,6 +1517,7 @@ class Dataset:
             test_ratio (float, optional): test num ratio (0 ~ 1).
             method (Union[str, SplitMethod], optional): split method. Defaults to SplitMethod.RANDOM.
             seed (int, optional): random seed. Defaults to 0.
+            strict (bool, optional): strict split. Defaults to True.
 
         Raises:
             ValueError: if train_ratio is not between 0.0 and 1.0.
@@ -1528,7 +1530,12 @@ class Dataset:
             [[1, 2, 3, 4, 5, 6, 7, 8], [9], [10], []]  # train, val, test, unlabeled image ids
         """
 
-        self._check_trainable()
+        if strict:
+            self._check_trainable()
+        else:
+            logger.warning(
+                "You are splitting dataset without restriction. It will bypass some dataset integrity checks. It can cause unexpected errors/results."
+            )
 
         if train_ratio <= 0.0 or train_ratio >= 1.0:
             raise ValueError(
@@ -1621,13 +1628,13 @@ class Dataset:
 
         return [train_ids, val_ids, test_ids, unlabeled_ids]
 
-    def export(self, data_type: Union[str, DataType], restrict: bool = True) -> str:
+    def export(self, data_type: Union[str, DataType], strict: bool = True) -> str:
         """
         Export Dataset to Specific data formats
 
         Args:
             data_type (Union[str, DataType]): export data type. one of ["YOLO", "COCO"].
-            restrict (bool, optional): restrict export. Defaults to True.
+            strict (bool, optional): strict export. Defaults to True.
 
         Raises:
             ValueError: if data_type is not one of DataType.
@@ -1644,7 +1651,7 @@ class Dataset:
             str: exported dataset directory
         """
 
-        if restrict:
+        if strict:
             self._check_trainable()
         else:
             logger.warning(

--- a/waffle_hub/dataset/dataset.py
+++ b/waffle_hub/dataset/dataset.py
@@ -1621,12 +1621,13 @@ class Dataset:
 
         return [train_ids, val_ids, test_ids, unlabeled_ids]
 
-    def export(self, data_type: Union[str, DataType]) -> str:
+    def export(self, data_type: Union[str, DataType], restrict: bool = True) -> str:
         """
         Export Dataset to Specific data formats
 
         Args:
             data_type (Union[str, DataType]): export data type. one of ["YOLO", "COCO"].
+            restrict (bool, optional): restrict export. Defaults to True.
 
         Raises:
             ValueError: if data_type is not one of DataType.
@@ -1643,9 +1644,15 @@ class Dataset:
             str: exported dataset directory
         """
 
-        self._check_trainable()
+        if restrict:
+            self._check_trainable()
+        else:
+            logger.warning(
+                "You are exporting dataset without restriction. It will bypass some dataset integrity checks. It can cause unexpected errors/results."
+            )
 
-        export_dir: Path = self.export_dir / EXPORT_MAP[data_type.upper()]
+        data_type_name = data_type.upper() if isinstance(data_type, str) else data_type.name
+        export_dir: Path = self.export_dir / EXPORT_MAP[data_type_name]
         if data_type in [DataType.YOLO, DataType.ULTRALYTICS]:
             export_function = export_yolo
         elif data_type in [DataType.COCO]:


### PR DESCRIPTION
- can export dataset bypassing `MINIMUM_TRAINABLE_IMAGE_NUM_PER_CATEGORY` restriction.
  ```python
  dataset.export("yolo", strict=False)
  ```